### PR TITLE
Add focus context for managing focus on route changes

### DIFF
--- a/packages/react-router/src/components/FocusContext/FocusContext.tsx
+++ b/packages/react-router/src/components/FocusContext/FocusContext.tsx
@@ -1,0 +1,26 @@
+import React, {useRef, useEffect, ReactNode, createRef} from 'react';
+import {FocusContext as Context} from '../../context';
+import {useCurrentUrl} from '../../hooks';
+import {Focusable} from '../../types';
+
+export function FocusContext({children}: {children: ReactNode}) {
+  const currentUrl = useCurrentUrl();
+  const focusRef = createRef<Focusable>();
+  const focus = () => {
+    const target = focusRef.current ?? document.body;
+    target.focus();
+  };
+
+  const firstRender = useRef(true);
+
+  useEffect(() => {
+    if (firstRender.current) {
+      firstRender.current = false;
+    } else {
+      focus();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [currentUrl.pathname]);
+
+  return <Context.Provider value={focusRef}>{children}</Context.Provider>;
+}

--- a/packages/react-router/src/components/FocusContext/index.tsx
+++ b/packages/react-router/src/components/FocusContext/index.tsx
@@ -1,0 +1,1 @@
+export {FocusContext} from './FocusContext';

--- a/packages/react-router/src/components/Router/Router.tsx
+++ b/packages/react-router/src/components/Router/Router.tsx
@@ -1,6 +1,7 @@
 import React, {memo, useState, useEffect, useRef, useMemo} from 'react';
 import {useSerialized} from '@quilted/react-html';
 
+import {FocusContext} from '../FocusContext';
 import {CurrentUrlContext, RouterContext} from '../../context';
 import {Router as RouterControl, EXTRACT} from '../../router';
 import {Prefetcher} from '../Prefetcher';
@@ -42,7 +43,7 @@ export const Router = memo(function Router({
       <RouterContext.Provider value={routerRef.current}>
         <CurrentUrlContext.Provider value={url}>
           <Prefetcher />
-          {children}
+          <FocusContext>{children}</FocusContext>
         </CurrentUrlContext.Provider>
       </RouterContext.Provider>
     </>

--- a/packages/react-router/src/components/index.ts
+++ b/packages/react-router/src/components/index.ts
@@ -5,3 +5,4 @@ export {Redirect} from './Redirect';
 export {Route} from './Route';
 export {Router} from './Router';
 export {Switch} from './Switch';
+export {FocusContext} from './FocusContext';

--- a/packages/react-router/src/context.ts
+++ b/packages/react-router/src/context.ts
@@ -1,8 +1,10 @@
-import {createContext} from 'react';
-import {EnhancedURL} from './types';
+import {createContext, RefObject} from 'react';
+import {EnhancedURL, Focusable} from './types';
 
 export const CurrentUrlContext = createContext<EnhancedURL | null>(null);
 export const RouterContext = createContext<import('./router').Router | null>(
   null,
 );
 export const SwitchContext = createContext<{matched(): void} | null>(null);
+
+export const FocusContext = createContext<RefObject<Focusable> | null>(null);

--- a/packages/react-router/src/hooks/focus.ts
+++ b/packages/react-router/src/hooks/focus.ts
@@ -1,0 +1,19 @@
+import {useContext} from 'react';
+
+import {FocusContext} from '../context';
+
+function useFocusContext() {
+  const context = useContext(FocusContext);
+
+  if (context == null) {
+    throw new Error(
+      'You attempted to use the focus context, but none was found. Make sure your code is nested in a <Router />',
+    );
+  }
+
+  return context;
+}
+
+export function useRouteChangeFocusRef() {
+  return useFocusContext();
+}

--- a/packages/react-router/src/hooks/index.ts
+++ b/packages/react-router/src/hooks/index.ts
@@ -1,3 +1,4 @@
 export {useCurrentUrl} from './url';
 export {useRouter} from './router';
 export {useNavigationBlock} from './navigation-block';
+export {useRouteChangeFocusRef} from './focus';

--- a/packages/react-router/src/index.ts
+++ b/packages/react-router/src/index.ts
@@ -7,5 +7,10 @@ export {
   Prefetcher,
   NavigationBlock,
 } from './components';
-export {useCurrentUrl, useRouter, useNavigationBlock} from './hooks';
+export {
+  useCurrentUrl,
+  useRouter,
+  useNavigationBlock,
+  useRouteChangeFocusRef,
+} from './hooks';
 export type {NavigateTo} from './router';

--- a/packages/react-router/src/testing.tsx
+++ b/packages/react-router/src/testing.tsx
@@ -2,6 +2,7 @@ import React, {useRef, ReactNode} from 'react';
 
 import {Router, NavigateTo, NavigateOptions, Options} from './router';
 import {CurrentUrlContext, RouterContext} from './context';
+import {FocusContext} from './components';
 
 class TestRouterControl extends Router {
   navigate(_to: NavigateTo, _options?: NavigateOptions) {}
@@ -26,7 +27,7 @@ export function TestRouter({children, router: initialRouter}: Props) {
   return (
     <RouterContext.Provider value={router.current}>
       <CurrentUrlContext.Provider value={router.current.currentUrl}>
-        {children}
+        <FocusContext>{children}</FocusContext>
       </CurrentUrlContext.Provider>
     </RouterContext.Provider>
   );

--- a/packages/react-router/src/types.ts
+++ b/packages/react-router/src/types.ts
@@ -8,3 +8,7 @@ export interface Matcher {
 }
 
 export type Match = string | RegExp | Matcher;
+
+export interface Focusable {
+  focus(): void;
+}


### PR DESCRIPTION
There's a lot of research and opinions on how to handle focus on route changes in SPA. Unfortunately, there's no one-size-fits-all solution; where the focus goes on route change depends on the application and on its context (for example, the focus on a single page could be different depending on whether there is a focus on the page or not). It could even change over time as user testing reveals better solutions. 

In order to support route change a11y out-of-the-box _and_ keep it generic enough to be used by multiple different apps, I've added a focus context to the router. This context provides as `focusRef` and a `focus` method (which calls `focus()` on the `focusRef`). The `focusRef` is exposed to consumers via the `useFocusRef` hook. The `focus` method is not exposed the consumers, but is called on every route change. This allows the consumer app to decide _what_ should receive focus on each route change, but the logic for _when_ this is called is up to the router itself. 