### PR TITLE
Fix typing for focus hook

### DIFF
--- a/packages/react-router/src/components/FocusContext/FocusContext.tsx
+++ b/packages/react-router/src/components/FocusContext/FocusContext.tsx
@@ -1,11 +1,11 @@
-import React, {useRef, useEffect, ReactNode, createRef} from 'react';
+import React, {useRef, useEffect, ReactNode} from 'react';
 import {FocusContext as Context} from '../../context';
 import {useCurrentUrl} from '../../hooks';
 import {Focusable} from '../../types';
 
 export function FocusContext({children}: {children: ReactNode}) {
   const currentUrl = useCurrentUrl();
-  const focusRef = createRef<Focusable>();
+  const focusRef = useRef<Focusable>();
   const focus = () => {
     const target = focusRef.current ?? document.body;
     target.focus();
@@ -19,7 +19,6 @@ export function FocusContext({children}: {children: ReactNode}) {
     } else {
       focus();
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUrl.pathname]);
 
   return <Context.Provider value={focusRef}>{children}</Context.Provider>;

--- a/packages/react-router/src/context.ts
+++ b/packages/react-router/src/context.ts
@@ -1,4 +1,4 @@
-import {createContext, RefObject} from 'react';
+import {createContext, MutableRefObject} from 'react';
 import {EnhancedURL, Focusable} from './types';
 
 export const CurrentUrlContext = createContext<EnhancedURL | null>(null);
@@ -7,4 +7,6 @@ export const RouterContext = createContext<import('./router').Router | null>(
 );
 export const SwitchContext = createContext<{matched(): void} | null>(null);
 
-export const FocusContext = createContext<RefObject<Focusable> | null>(null);
+export const FocusContext = createContext<MutableRefObject<
+  Focusable | undefined | null
+> | null>(null);

--- a/packages/react-router/src/hooks/focus.ts
+++ b/packages/react-router/src/hooks/focus.ts
@@ -1,8 +1,11 @@
-import {useContext} from 'react';
+import {useContext, MutableRefObject} from 'react';
 
+import {Focusable} from '../types';
 import {FocusContext} from '../context';
 
-function useFocusContext() {
+export function useRouteChangeFocusRef<T extends Focusable>(): MutableRefObject<
+  T
+> {
   const context = useContext(FocusContext);
 
   if (context == null) {
@@ -11,9 +14,5 @@ function useFocusContext() {
     );
   }
 
-  return context;
-}
-
-export function useRouteChangeFocusRef() {
-  return useFocusContext();
+  return context as MutableRefObject<T>;
 }


### PR DESCRIPTION
This PR fixes the typing for the `useRouteChangeFocusRef` hook. 