### PR TITLE
[react-router] Add appPath to EnhancedUrl, defining a pathname of the app minus the prefix parts

### DIFF
--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -282,8 +282,15 @@ function enhanceUrl(url: URL, state: object, prefix?: Prefix): EnhancedURL {
     writable: true,
   });
 
+  const extractedPrefix = extractPrefix(url, prefix);
   Object.defineProperty(url, 'prefix', {
-    value: extractPrefix(url, prefix),
+    value: extractedPrefix,
+    writable: false,
+  });
+
+  const normalizedPath = url.pathname.replace(extractedPrefix ?? '', '');
+  Object.defineProperty(url, 'normalizedPath', {
+    value: normalizedPath,
     writable: false,
   });
 

--- a/packages/react-router/src/types.ts
+++ b/packages/react-router/src/types.ts
@@ -1,5 +1,10 @@
 export type EnhancedURL = URL & {
   readonly prefix?: string;
+
+  /**
+   * The pathname of the app discarding the prefix part
+   */
+  readonly normalizedPath: string;
   readonly state: {key?: string; [key: string]: unknown};
 };
 

--- a/packages/react-router/src/utilities.ts
+++ b/packages/react-router/src/utilities.ts
@@ -5,7 +5,10 @@ export function postfixSlash(path: string) {
   return path.lastIndexOf('/') === path.length - 1 ? path : `${path}/`;
 }
 
-export function resolveMatch(url: Omit<EnhancedURL, 'state'>, match: Match) {
+export function resolveMatch(
+  url: Omit<EnhancedURL, 'state' | 'normalizedPath'>,
+  match: Match,
+) {
   if (typeof match === 'string') {
     const pathname = remainder(url.pathname, url.prefix);
     return match === pathname || (pathname !== '/' && match === `${pathname}/`);


### PR DESCRIPTION
This allows us to more quickly get at the effective pathname when there's a prefix in play without doing all this normalizing everywhere within the consuming app