### PR TITLE
Allow to set relativeTo when redirecting

### DIFF
--- a/packages/react-router/src/components/Redirect/Redirect.test.tsx
+++ b/packages/react-router/src/components/Redirect/Redirect.test.tsx
@@ -12,6 +12,18 @@ describe('<Redirect />', () => {
       replace: true,
     });
   });
+
+  it('works with relativeTo', () => {
+    const to = '/my/path';
+    const redirect = mountWithNavigateSpy(
+      <Redirect to={to} relativeTo="root" />,
+    );
+
+    expect(redirect.context.router.navigate).toHaveBeenCalledWith(to, {
+      replace: true,
+      relativeTo: 'root',
+    });
+  });
 });
 
 type MockedRouter = Omit<ReturnType<typeof createTestRouter>, 'navigate'> & {

--- a/packages/react-router/src/components/Redirect/Redirect.tsx
+++ b/packages/react-router/src/components/Redirect/Redirect.tsx
@@ -1,11 +1,12 @@
 import {useRedirect} from '../../hooks';
-import type {NavigateTo} from '../../types';
+import type {NavigateTo, RelativeTo} from '../../types';
 
 interface Props {
   to: NavigateTo;
+  relativeTo?: RelativeTo;
 }
 
-export function Redirect({to}: Props) {
-  useRedirect(to);
+export function Redirect({to, relativeTo}: Props) {
+  useRedirect(to, {relativeTo});
   return null;
 }

--- a/packages/react-router/src/hooks/redirect.ts
+++ b/packages/react-router/src/hooks/redirect.ts
@@ -1,12 +1,16 @@
 import {useEffect} from 'react';
+import {NavigateOptions} from 'router';
 import type {NavigateTo} from '../types';
 
 import {useNavigate} from './navigate';
 
-export function useRedirect(to: NavigateTo) {
+export function useRedirect(
+  to: NavigateTo,
+  {relativeTo}: NavigateOptions = {},
+) {
   const navigate = useNavigate();
 
   useEffect(() => {
-    navigate(to, {replace: true});
-  }, [navigate, to]);
+    navigate(to, {replace: true, relativeTo});
+  }, [navigate, relativeTo, to]);
 }

--- a/packages/react-router/src/router.ts
+++ b/packages/react-router/src/router.ts
@@ -1,4 +1,10 @@
-import type {EnhancedURL, Prefix, NavigateTo, Blocker} from './types';
+import type {
+  EnhancedURL,
+  Prefix,
+  NavigateTo,
+  Blocker,
+  RelativeTo,
+} from './types';
 import {enhanceUrl, createKey, resolveUrl} from './utilities';
 
 export const SERVER_RENDER_EFFECT_ID = Symbol('router');
@@ -16,6 +22,7 @@ type Listener = (url: EnhancedURL) => void;
 
 export interface NavigateOptions {
   replace?: boolean;
+  relativeTo?: RelativeTo;
   state?: State;
 }
 
@@ -83,11 +90,11 @@ export function createRouter(
 
   function navigate(
     to: NavigateTo,
-    {state = {}, replace = false}: NavigateOptions = {},
+    {state = {}, replace = false, relativeTo}: NavigateOptions = {},
   ) {
     const resolvedKey = createKey();
     const resolvedUrl = enhanceUrl(
-      resolveUrl(to, currentUrl),
+      resolveUrl(to, currentUrl, relativeTo),
       state,
       resolvedKey,
       prefix,
@@ -97,7 +104,7 @@ export function createRouter(
 
     const redo = () => {
       forceNextNavigation = true;
-      navigate(resolvedUrl, {state, replace});
+      navigate(resolvedUrl, {state, replace, relativeTo});
     };
 
     if (!forceNextNavigation && shouldBlock(resolvedUrl, redo)) {

--- a/packages/react-router/src/tests/utilities.test.ts
+++ b/packages/react-router/src/tests/utilities.test.ts
@@ -1,0 +1,44 @@
+import {enhanceUrl, resolveUrl} from '../utilities';
+
+describe('utilities', () => {
+  describe('resolveUrl()', () => {
+    it('uses the origin prefix when no relativeTo is passed', () => {
+      const resolvedUrl = resolveUrl(
+        '/b',
+        enhanceUrl(
+          new URL('http://example.com/prefix/a'),
+          {},
+          'key',
+          '/prefix',
+        ),
+      );
+
+      expect(resolvedUrl.pathname).toBe('/prefix/b');
+    });
+
+    it('uses root when relativeTo is root', () => {
+      const resolvedUrl = resolveUrl(
+        '/b',
+        enhanceUrl(
+          new URL('http://example.com/prefix/a'),
+          {},
+          'key',
+          '/prefix',
+        ),
+        'root',
+      );
+
+      expect(resolvedUrl.pathname).toBe('/b');
+    });
+
+    it('uses the current prefix when relativeTo is prefix', () => {
+      const resolvedUrl = resolveUrl(
+        '/b',
+        enhanceUrl(new URL('http://example.com/1/2/a'), {}, 'key', '/1/2'),
+        'prefix',
+      );
+
+      expect(resolvedUrl.pathname).toBe('/1/2/b');
+    });
+  });
+});

--- a/packages/react-router/src/types.ts
+++ b/packages/react-router/src/types.ts
@@ -57,3 +57,5 @@ export interface RouteDefinition {
   render?(details: RouteRenderDetails): ReactNode;
   renderPrefetch?(details: RouteRenderPrefetchDetails): ReactNode;
 }
+
+export type RelativeTo = 'root' | 'prefix';

--- a/packages/react-router/src/utilities.ts
+++ b/packages/react-router/src/utilities.ts
@@ -1,4 +1,11 @@
-import type {Match, Prefix, EnhancedURL, NavigateTo, Search} from './types';
+import type {
+  Match,
+  Prefix,
+  EnhancedURL,
+  NavigateTo,
+  Search,
+  RelativeTo,
+} from './types';
 import type {Router} from './router';
 
 export function enhanceUrl(
@@ -35,7 +42,13 @@ export function enhanceUrl(
   return url as EnhancedURL;
 }
 
-export function resolveUrl(to: NavigateTo, from: EnhancedURL): URL {
+export function resolveUrl(
+  to: NavigateTo,
+  from: EnhancedURL,
+  relativeTo?: RelativeTo,
+): URL {
+  const prefix = relativeTo === 'root' ? '/' : from.prefix;
+
   if (to instanceof URL) {
     if (to.origin !== from.origin) {
       throw new Error(
@@ -52,14 +65,14 @@ export function resolveUrl(to: NavigateTo, from: EnhancedURL): URL {
     const finalHash = prefixIfNeeded('#', hash);
 
     return new URL(
-      prefixPath(`${finalPathname}${finalSearch}${finalHash}`, from.prefix),
+      prefixPath(`${finalPathname}${finalSearch}${finalHash}`, prefix),
       from.href,
     );
   } else if (typeof to === 'function') {
-    return resolveUrl(to(from), from);
+    return resolveUrl(to(from), from, relativeTo);
   }
 
-  return new URL(prefixPath(to, from.prefix), postfixSlash(from.href));
+  return new URL(prefixPath(to, prefix), postfixSlash(from.href));
 }
 
 function prefixPath(pathname: string, prefix?: string) {


### PR DESCRIPTION
### Description

Enable us to not be constrained by the existing router prefix when redirecting.