### PR TITLE
Add hook testing

### DIFF
--- a/packages/react-testing/src/HookRunner.tsx
+++ b/packages/react-testing/src/HookRunner.tsx
@@ -1,0 +1,28 @@
+import {forwardRef, useRef, useImperativeHandle} from 'react';
+import type {Ref, ReactElement} from 'react';
+
+interface Props<HookResult = unknown> {
+  useHook(): HookResult;
+}
+
+export interface ImperativeApi<HookResult = unknown> {
+  readonly current: HookResult;
+}
+
+export const HookRunner = forwardRef<ImperativeApi, Props>(
+  ({useHook}: Props, ref) => {
+    const hookResult = useHook();
+    const valueRef = useRef(hookResult);
+    valueRef.current = hookResult;
+
+    useImperativeHandle(ref, () => ({
+      get current() {
+        return valueRef.current;
+      },
+    }));
+
+    return null;
+  },
+) as <HookResult>(
+  props: Props<HookResult> & {ref?: Ref<ImperativeApi<HookResult>>},
+) => ReactElement | null;

--- a/packages/react-testing/src/implementations/preact.ts
+++ b/packages/react-testing/src/implementations/preact.ts
@@ -3,8 +3,8 @@ import type {VNode, ComponentChild, Component} from 'preact';
 import {createPortal} from 'preact/compat';
 import {act} from 'preact/test-utils';
 
-import {createEnvironment, isNode, Environment} from '../environment';
-import type {CustomMount} from '../environment';
+import {createEnvironment, isNode} from '../environment';
+import type {CustomMount, EnvironmentOptions} from '../environment';
 import type {Node, Root, RootNode, HtmlNodeExtensions} from '../types';
 
 interface Context {
@@ -38,7 +38,9 @@ const {mount, createMount, mounted, unmountAll} = createEnvironment<
 
 export {mount, createMount, mounted, unmountAll};
 
-type Create = Parameters<Environment<any, HtmlNodeExtensions>['update']>[1];
+type Create = Parameters<
+  EnvironmentOptions<any, HtmlNodeExtensions>['update']
+>[1];
 type Child = ReturnType<Create> | string;
 
 function createNodeFromComponentChild(

--- a/packages/react-testing/src/implementations/react-dom.ts
+++ b/packages/react-testing/src/implementations/react-dom.ts
@@ -1,8 +1,8 @@
 import {render, unmountComponentAtNode} from 'react-dom';
 import {act} from 'react-dom/test-utils';
 
-import {createEnvironment, Environment, isNode} from '../environment';
-import type {CustomMount} from '../environment';
+import {createEnvironment, isNode} from '../environment';
+import type {CustomMount, EnvironmentOptions} from '../environment';
 import type {Node, Root, RootNode, HtmlNodeExtensions} from '../types';
 
 import {Tag} from './shared/react';
@@ -42,7 +42,9 @@ const {mount, createMount, mounted, unmountAll} = createEnvironment<
 
 export {mount, createMount, mounted, unmountAll};
 
-type Create = Parameters<Environment<any, HtmlNodeExtensions>['update']>[1];
+type Create = Parameters<
+  EnvironmentOptions<any, HtmlNodeExtensions>['update']
+>[1];
 type Child = ReturnType<Create> | string;
 
 export function createNodeFromFiber(element: any, create: Create): Child {

--- a/packages/react-testing/src/implementations/shared/react.ts
+++ b/packages/react-testing/src/implementations/shared/react.ts
@@ -1,4 +1,4 @@
-import type {Environment} from '../../environment';
+import type {EnvironmentOptions} from '../../environment';
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const {findCurrentFiberUsingSlowPath} = require('react-reconciler/reflection');
@@ -46,7 +46,7 @@ export interface ReactInstance {
   _reactInternalFiber: Fiber;
 }
 
-type Create = Parameters<Environment<any>['update']>[1];
+type Create = Parameters<EnvironmentOptions<any>['update']>[1];
 type Child = ReturnType<Create> | string;
 
 export function createNodeFromFiber(element: any, create: Create): Child {

--- a/packages/react-testing/src/implementations/test-renderer.ts
+++ b/packages/react-testing/src/implementations/test-renderer.ts
@@ -5,8 +5,8 @@ import {
   ReactTestInstance,
 } from 'react-test-renderer';
 
-import {createEnvironment, Environment, isNode} from '../environment';
-import type {CustomMount} from '../environment';
+import {createEnvironment, isNode} from '../environment';
+import type {CustomMount, EnvironmentOptions} from '../environment';
 import type {Node, Root, RootNode} from '../types';
 
 interface Context {
@@ -30,7 +30,7 @@ const {mount, createMount, mounted, unmountAll} = createEnvironment<Context>({
   },
 });
 
-type Create = Parameters<Environment<any>['update']>[1];
+type Create = Parameters<EnvironmentOptions<any>['update']>[1];
 
 function createNodeFromTestInstance(
   testInstance: ReactTestInstance,

--- a/packages/react-testing/src/tests/environment.test.tsx
+++ b/packages/react-testing/src/tests/environment.test.tsx
@@ -1,0 +1,24 @@
+import {useState} from 'react';
+import {mount} from '../implementations/test-renderer';
+
+describe('mount()', () => {
+  describe('hook()', () => {
+    it('provides the current hook return value', () => {
+      const initialState = 1;
+      const hookRunner = mount.hook(() => useState(initialState));
+      expect(hookRunner).toHaveProperty('current', [
+        initialState,
+        expect.any(Function),
+      ]);
+    });
+
+    it('provides an act() method that is called with the current hook value, and resolves all pending updates', () => {
+      const initialState = 1;
+      const hookRunner = mount.hook(() => useState(initialState));
+
+      hookRunner.act(([, setState]) => setState(initialState + 1));
+
+      expect(hookRunner).toHaveProperty('current.0', initialState + 1);
+    });
+  });
+});


### PR DESCRIPTION
I've seen one-off versions of hook testing functions in a bunch of repos. This PR adds this as a new method on every `mount()` function, `mount.hook()`. This method lets you pass a function to run as a hook, as well as any options the mount function might take. It returns a "hook runner" that gives you access to the same context/ actions a mounted component could have, as well as a `value` method that gives you access to the most recent hook result, and an `act()` that lets you easily call functions on that result within a React act() block.

I also took the chance to modernize the "runner" components to by function components, and added a few tests (tests for a testing library — insert preferred meme here).