### PR TITLE
Fixes broken link to react test-utils act()

### DIFF
--- a/packages/react-testing/README.md
+++ b/packages/react-testing/README.md
@@ -412,7 +412,7 @@ Allows you to change a subset of the props specified when the component was orig
 
 ##### <a name="act"></a> `act<T>(action: () => T): T`
 
-Performs an action in the context of a react [`act() block`](https://github.com/reactjs/react/blob/master/test-utils/src/index.js#L27), then updates the internal representation of the react tree. You **must** use this whenever performing an action that will cause the react tree to set state and re-render, such as simulating event listeners being called. Failing to do so will print a warning, and the react tree will not be updated for subsequent calls to methods such as `find()`.
+Performs an action in the context of a react [`act() block`](https://github.com/facebook/react/blob/master/packages/react-dom/src/test-utils/ReactTestUtilsPublicAct.js#L76), then updates the internal representation of the react tree. You **must** use this whenever performing an action that will cause the react tree to set state and re-render, such as simulating event listeners being called. Failing to do so will print a warning, and the react tree will not be updated for subsequent calls to methods such as `find()`.
 
 ```tsx
 function MyComponent() {


### PR DESCRIPTION
This corrects the link to the React test-utils `act()` function. It looks like Facebook had reorganized the react repo since this link was inserted. We also were using a different org than where react is hosted right now.

I do wonder if it is better to link to the [public documentation for `act()`](https://reactjs.org/docs/test-utils.html#act) rather than its location in GitHub source control, since the latter can go out of date and thus lead us to another broken link issue. I'll leave that up to you to decide, @lemonmade.