### PR TITLE
Add tests showcasing context issue

### DIFF
--- a/packages/react-testing/src/tests/environment.test.tsx
+++ b/packages/react-testing/src/tests/environment.test.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useState, createContext} from 'react';
 import {mount} from '../implementations/test-renderer';
 
 describe('mount()', () => {
@@ -19,6 +19,34 @@ describe('mount()', () => {
       hookRunner.act(([, setState]) => setState(initialState + 1));
 
       expect(hookRunner).toHaveProperty('current.0', initialState + 1);
+    });
+
+    it('child component is find-able', () => {
+      function InnerComponent() {
+        return null;
+      }
+      function RootComponent() {
+        return <InnerComponent />;
+      }
+      const wrapper = mount(<RootComponent />);
+      expect(wrapper.find(InnerComponent)).not.toBeNull();
+    });
+
+    it.only('child comntext component is find-able', () => {
+      const ContextComponent = createContext('defaultValue');
+      function InnerComponent() {
+        return null;
+      }
+
+      function TestComponent() {
+        return (
+          <ContextComponent.Provider value="defaultValue">
+            <InnerComponent />
+          </ContextComponent.Provider>
+        );
+      }
+      const wrapper = mount(<TestComponent />);
+      expect(wrapper.find(ContextComponent.Provider)).not.toBeNull();
     });
   });
 });


### PR DESCRIPTION
This is not really a PR, I just added a test showcasing the issue. 
Apparently, react-test-renderer is not outputting in the tree a lot of "invisible" component types including `Context.Provider` and `Context.Consumer`

also, shopify/web tests relies quite a lot on being able to find Context.Provider in the rendered tree. 