### PR TITLE
Throw render errors in testing library

### DIFF
--- a/packages/react-testing/src/TestRenderer.tsx
+++ b/packages/react-testing/src/TestRenderer.tsx
@@ -3,6 +3,7 @@ import type {ReactElement, ReactNode} from 'react';
 
 interface State<ComponentProps> {
   props?: Partial<ComponentProps>;
+  error?: Error;
 }
 
 interface Props<ComponentProps> {
@@ -16,14 +17,25 @@ export class TestRenderer<ComponentProps> extends Component<
   Props<ComponentProps>,
   State<ComponentProps>
 > {
+  static getDerivedStateFromError(error: any) {
+    return {error};
+  }
+
   state: State<ComponentProps> = {};
 
   setProps(props: Partial<ComponentProps>) {
     this.setState({props});
   }
 
+  getError() {
+    return this.state.error;
+  }
+
   render() {
-    const {props} = this.state;
+    const {props, error} = this.state;
+
+    if (error) return null;
+
     const {children, render = defaultRender} = this.props;
     return render(
       props ? (cloneElement(children as any, props) as any) : children!,

--- a/packages/react-testing/src/environment.tsx
+++ b/packages/react-testing/src/environment.tsx
@@ -525,8 +525,8 @@ export function createEnvironment<
       acting = true;
 
       const afterResolve = () => {
-        performUpdate();
         acting = false;
+        performUpdate();
         return result;
       };
 
@@ -557,12 +557,19 @@ export function createEnvironment<
     }
 
     function updateRootNode() {
-      rootNode =
-        testRendererRef.current == null
-          ? null
-          : env.update(testRendererRef.current, createNode, context);
+      const testRenderer = testRendererRef.current;
 
+      if (testRenderer == null) {
+        rootNode = null;
+        return;
+      }
+
+      rootNode = env.update(testRenderer, createNode, context);
       rootNode = rootNode && resolveRoot(rootNode);
+
+      const error = testRenderer.getError();
+
+      if (error) throw error;
     }
 
     function withRootNode<T>(perform: (node: Node<unknown>) => T) {

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -1,0 +1,58 @@
+/* eslint no-console: off */
+
+import {useState} from 'react';
+import {mount} from '..';
+
+describe('e2e', () => {
+  let consoleError = console.error;
+
+  beforeEach(() => {
+    consoleError = console.error;
+
+    // React logs these errors no matter what, even though we
+    // catch the error in the test runner.
+    console.error = (...args: any[]) => {
+      if (
+        typeof args[0] === 'string' &&
+        args[0].includes('<ThrowingComponent>')
+      ) {
+        return;
+      }
+
+      return consoleError.call(console, ...args);
+    };
+  });
+
+  afterEach(() => {
+    console.error = consoleError;
+  });
+
+  it('throws if an React component throws during mount', () => {
+    const error = new Error('oh no!');
+
+    function ThrowingComponent() {
+      throw error;
+      return null;
+    }
+
+    expect(() => mount(<ThrowingComponent />)).toThrowError(error);
+  });
+
+  it('throws if a React component throws after an update', () => {
+    const error = new Error('oh no!');
+
+    function ThrowingComponent() {
+      const [shouldThrow, setShouldThrow] = useState(false);
+
+      if (shouldThrow) throw error;
+
+      return <button onClick={() => setShouldThrow(true)}>Throw!</button>;
+    }
+
+    const throwingComponent = mount(<ThrowingComponent />);
+
+    expect(() =>
+      throwingComponent.find('button')!.trigger('onClick'),
+    ).toThrowError(error);
+  });
+});

--- a/packages/react-testing/src/tests/e2e.test.tsx
+++ b/packages/react-testing/src/tests/e2e.test.tsx
@@ -1,6 +1,6 @@
 /* eslint no-console: off */
 
-import {useState} from 'react';
+import {Component, useState} from 'react';
 import {mount} from '..';
 
 describe('e2e', () => {
@@ -54,5 +54,34 @@ describe('e2e', () => {
     expect(() =>
       throwingComponent.find('button')!.trigger('onClick'),
     ).toThrowError(error);
+  });
+
+  it('does not throw an error when an intermediate error boundary intercepts the error', () => {
+    const error = new Error('oh no!');
+
+    class ErrorBoundary extends Component {
+      state: {error?: Error} = {};
+
+      static getDerivedStateFromError(error: any) {
+        return {error};
+      }
+
+      render() {
+        return this.state.error ? null : <>{this.props.children}</>;
+      }
+    }
+
+    function ThrowingComponent() {
+      throw error;
+      return null;
+    }
+
+    expect(() =>
+      mount(
+        <ErrorBoundary>
+          <ThrowingComponent />
+        </ErrorBoundary>,
+      ),
+    ).not.toThrowError();
   });
 });


### PR DESCRIPTION
After some discussions yesterday, I was convinced that uncaught rendering errors should be propagated by the testing library. This PR makes it so that after any method that causes the library to update its representation of the tree (`mount()`, `act()`, `trigger()`, etc), this library will throw an error if an error wound up at the root component.

Thanks @kumar303 for convincing me!