### PR TITLE
react-testing: Fix casing mismatch with preact/compat

### DIFF
--- a/packages/react-testing/source/implementations/preact.ts
+++ b/packages/react-testing/source/implementations/preact.ts
@@ -60,7 +60,7 @@ function createNodeFromComponentChild(
 
 // Check that we have a native DOM node and not a custom element
 function isDomVNode(vnode: VNode) {
-  return typeof vnode.type === "string" && vnode.type.indexOf("-") === -1
+  return typeof vnode.type === "string" && !vnode.type.includes("-");
 }
 
 // Preact may modify property names and assign a new props object when
@@ -72,7 +72,8 @@ options.vnode = (vnode) => {
   if (isDomVNode(vnode)) {
     originalProps.set(vnode, vnode.props);
   }
-  if (oldVNodeHook) oldVNodeHook(vnode)
+
+  oldVNodeHook?.(vnode)
 }
 
 function createNodeFromVNode(node: VNode<unknown>, create: Create): Child {


### PR DESCRIPTION
This PR addresses an issue in regards to the casing of prop names, when `preact/compat` is involved.

```jsx
const spy = jest.fn();
const node = await mount(<input onInput={spy} />);

// This would throw because compat normalizes `onInput` -> `oninput`
node.find("input").trigger("onInput");
```

The solution picked here is a bit heavy handed, by keeping a reference to the original `props` object around. On the plus side, this ensures that the testing library asserts on the original props object, which seems to be the spirit of it.