### PR TITLE
Use entry.key as the Preact key in useRoutes

### DIFF
--- a/.changeset/route-element-key.md
+++ b/.changeset/route-element-key.md
@@ -1,0 +1,36 @@
+---
+'@quilted/preact-router': minor
+---
+
+Use `entry.key` (not `entry.id`) as the Preact `key` for each rendered route
+
+Previously, `useRoutes` used `entry.id` as the Preact `key` on every `RouteNavigationRenderer` in the stack. `entry.id` is constructed as `${matchID}:${loadID}` where `matchID` starts with the per-navigation `request.id`, so it changed on every call to `navigation.navigate()`. Preact treats a single child whose `key` has changed as a different element, so the entire matched route tree — including persistent parent frames — unmounted and remounted on every navigation. That destroyed state in parent layouts (top bars, section nav, persistent models), replayed CSS transitions from scratch, and threw away Preact reconciliation work.
+
+`entry.key` already exists for this exact purpose: it's derived from the route's match (stable per logical route pattern) or from a user-supplied `route.key` string / array / function. Switching the renderer to use `entry.key` means:
+
+- Navigating to the same logical route keeps the same component instance mounted.
+- Navigating to a different route pattern (or one where the user's `key` function returns a different value) remounts as you'd expect.
+- The `key` option on route definitions, which until now only influenced load caching, now also does what its name implies — it controls reconciliation.
+
+```tsx
+useRoutes([
+  // Persistent top-bar frame — stays mounted across all child navigations.
+  {
+    match: true,
+    render: (children) => <Frame>{children}</Frame>,
+    children: [
+      {match: '/activities', render: <ActivitiesPage />},
+      {match: '/staff', render: <StaffPage />},
+
+      // Dynamic route with a custom key: remount only when :id changes,
+      // not on every navigation to the same id.
+      route(/[/]activity[/](?<id>[\w-]+)/, {
+        key: (entry) => entry.matched.groups?.id,
+        render: <ActivityDetailPage />,
+      }),
+    ],
+  },
+]);
+```
+
+**Breaking change for apps that rely on the remount-per-navigation side effect** (fresh `useState` / `useEffect` re-running on every navigation, even to the same URL). If you need that behavior, supply a `key` function that returns a new value each call (e.g. `key: () => Math.random()`).

--- a/packages/preact-router/package.json
+++ b/packages/preact-router/package.json
@@ -57,6 +57,7 @@
     }
   },
   "devDependencies": {
+    "@quilted/preact-signals": "workspace:*",
     "@quilted/preact-testing": "workspace:*",
     "preact": "^10.29.0"
   }

--- a/packages/preact-router/source/hooks/routes.tsx
+++ b/packages/preact-router/source/hooks/routes.tsx
@@ -66,7 +66,9 @@ function RouteStackRenderer({
   for (const entry of [...entries].reverse()) {
     content = (
       <RouteNavigationRenderer
-        key={entry.id}
+        key={
+          typeof entry.key === 'string' ? entry.key : JSON.stringify(entry.key)
+        }
         navigation={navigation}
         entry={entry}
       >

--- a/packages/preact-router/source/tests/e2e.test.tsx
+++ b/packages/preact-router/source/tests/e2e.test.tsx
@@ -1,9 +1,16 @@
 // @vitest-environment jsdom
+// @vitest-environment-options {"url": "https://example.com/"}
+
+// Importing `@quilted/preact-signals` installs the Preact <-> signals render
+// integration so that `.value` reads during render subscribe the component.
+import '@quilted/preact-signals';
 
 import {describe, it, expect, afterEach, vi} from 'vitest';
 import type {RenderableProps} from 'preact';
+import {useEffect} from 'preact/hooks';
 
 import {
+  Navigation,
   route,
   useRoutes,
   useRouteData,
@@ -837,6 +844,138 @@ describe('useRoutes()', () => {
           data: {id: 'a', title: 'A resource'},
         }),
       );
+    });
+  });
+
+  describe('key', () => {
+    function createMountTracker() {
+      const mountSpy = vi.fn<(label: string) => void>();
+
+      function Tracker({label}: {label: string}) {
+        useEffect(() => {
+          mountSpy(label);
+        }, []);
+
+        return <div>Tracker: {label}</div>;
+      }
+
+      return {mountSpy, Tracker};
+    }
+
+    it('preserves the component instance across navigations to the same route', () => {
+      const {mountSpy, Tracker} = createMountTracker();
+      const navigation = new Navigation(
+        new URL('https://example.com/activities'),
+      );
+
+      function Routes() {
+        return useRoutes([
+          {
+            match: true,
+            render: (children) => <>{children}</>,
+            children: [
+              {match: '/activities', render: <Tracker label="activities" />},
+              {match: '/staff', render: <Tracker label="staff" />},
+            ],
+          },
+        ]);
+      }
+
+      const routes = render(<Routes />, {navigation});
+
+      expect(mountSpy).toHaveBeenCalledTimes(1);
+      expect(mountSpy).toHaveBeenLastCalledWith('activities');
+
+      // Navigating to the same URL derives the same key, so the component
+      // instance is reused rather than remounted.
+      routes.act(() => {
+        navigation.navigate('/activities');
+      });
+
+      expect(mountSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('remounts when navigating to a route with a different derived key', () => {
+      const {mountSpy, Tracker} = createMountTracker();
+      const navigation = new Navigation(
+        new URL('https://example.com/activities'),
+      );
+
+      function Routes() {
+        return useRoutes([
+          {
+            match: true,
+            render: (children) => <>{children}</>,
+            children: [
+              {match: '/activities', render: <Tracker label="activities" />},
+              {match: '/staff', render: <Tracker label="staff" />},
+            ],
+          },
+        ]);
+      }
+
+      const routes = render(<Routes />, {navigation});
+
+      expect(mountSpy).toHaveBeenCalledTimes(1);
+      expect(mountSpy).toHaveBeenLastCalledWith('activities');
+
+      // Different match pattern → different key → remount.
+      routes.act(() => {
+        navigation.navigate('/staff');
+      });
+
+      expect(mountSpy).toHaveBeenCalledTimes(2);
+      expect(mountSpy).toHaveBeenLastCalledWith('staff');
+      expect(routes).toContainPreactText('Tracker: staff');
+    });
+
+    it('uses a user-supplied key function to control remount boundaries', () => {
+      const {mountSpy, Tracker} = createMountTracker();
+      const navigation = new Navigation(
+        new URL('https://example.com/activity/a'),
+      );
+
+      const keySpy = vi.fn(
+        (entry: {matched: RegExpMatchArray}) => entry.matched.groups?.id,
+      );
+
+      function Routes() {
+        return useRoutes([
+          {
+            match: true,
+            render: (children) => <>{children}</>,
+            children: [
+              route(/[/]activity[/](?<id>[\w-]+)/, {
+                key: (entry) => keySpy(entry as any),
+                render: (_, entry) => (
+                  <Tracker label={entry.matched.groups?.id ?? ''} />
+                ),
+              }),
+            ],
+          },
+        ]);
+      }
+
+      const routes = render(<Routes />, {navigation});
+
+      expect(mountSpy).toHaveBeenCalledTimes(1);
+      expect(mountSpy).toHaveBeenLastCalledWith('a');
+
+      // Same id → same key → same instance.
+      routes.act(() => {
+        navigation.navigate('/activity/a');
+      });
+
+      expect(mountSpy).toHaveBeenCalledTimes(1);
+
+      // Different id → different key → remount.
+      routes.act(() => {
+        navigation.navigate('/activity/b');
+      });
+
+      expect(mountSpy).toHaveBeenCalledTimes(2);
+      expect(mountSpy).toHaveBeenLastCalledWith('b');
+      expect(keySpy).toHaveBeenCalled();
     });
   });
 });

--- a/packages/preact-router/source/tests/utilities.tsx
+++ b/packages/preact-router/source/tests/utilities.tsx
@@ -4,14 +4,15 @@ import {matchers, type CustomMatchers} from '@quilted/preact-testing/matchers';
 import {createRender, destroyAll} from '@quilted/preact-testing';
 
 import {QuiltFrameworkContextPreact} from '@quilted/preact-context';
+import {Navigation} from '../Navigation.ts';
 import {TestNavigation} from '../testing.tsx';
 
 export {TestNavigation, destroyAll};
 
 export const render = createRender<
-  | {navigation?: TestNavigation; path?: never; base?: never}
+  | {navigation?: Navigation; path?: never; base?: never}
   | {navigation?: never; path?: `/${string}`; base?: string | URL},
-  {navigation: TestNavigation}
+  {navigation: Navigation}
 >({
   context({
     path = '/',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -756,6 +756,9 @@ importers:
         specifier: workspace:^0.2.4
         version: link:../signals
     devDependencies:
+      '@quilted/preact-signals':
+        specifier: workspace:*
+        version: link:../preact-signals
       '@quilted/preact-testing':
         specifier: workspace:*
         version: link:../preact-testing


### PR DESCRIPTION
## Summary

One-line change: `useRoutes` now uses `entry.key` as the Preact `key` on each `RouteNavigationRenderer` in the route stack, instead of `entry.id`.

## Why

`entry.id` is constructed as `\${matchID}:\${loadID}` where `matchID` starts with the per-navigation `request.id` ([`Navigation.ts#L259`](https://github.com/lemonmade/quilt/blob/main/packages/preact-router/source/Navigation.ts#L259), [`#L83`](https://github.com/lemonmade/quilt/blob/main/packages/preact-router/source/Navigation.ts#L83)), so it changed on every call to `navigation.navigate()`. Passing that as the Preact `key` made Preact treat every matched element as a new one on every navigation, unmounting and remounting the entire route tree — including persistent parent frames — each time.

Symptoms in consuming apps:

- Top-bar / side-nav state (`useState`, `useMemo`, signal-backed models) silently reset on every navigation.
- CSS transitions driven by class changes on a persistent element never ran, because the element was a fresh mount each time.
- Image-load fade-ins and other first-paint animations replayed on every click.

`entry.key` already exists as the logical-route identifier ([`Navigation.ts#L312-338`](https://github.com/lemonmade/quilt/blob/main/packages/preact-router/source/Navigation.ts#L312-L338)). It's stable for the same match + consumed path, or the return value of the user-supplied `route.key` string / array / function. It was only being used for load caching — switching the renderer to use it means the `key` option now controls reconciliation, which is what its name implies.

## The change

[`hooks/routes.tsx#L67-76`](https://github.com/lemonmade/quilt/blob/main/packages/preact-router/source/hooks/routes.tsx#L67-L76):

```diff
  for (const entry of [...entries].reverse()) {
    content = (
      <RouteNavigationRenderer
-       key={entry.id}
+       key={
+         typeof entry.key === 'string' ? entry.key : JSON.stringify(entry.key)
+       }
        navigation={navigation}
        entry={entry}
      >
        {content}
      </RouteNavigationRenderer>
    );
  }
```

Load lifecycle is unaffected: the `AsyncAction` is still cached by `loadID` in `loadCache`, so `entry.load.hasFinished` persists across revisits and the renderer's `untracked(() => { if (!entry.load.hasFinished) throw entry.load.run(...) })` check doesn't produce spurious suspends.

## Tests

Three new tests in `describe('key')` inside `packages/preact-router/source/tests/e2e.test.tsx`:

1. Navigating to the same URL reuses the same component instance (`useEffect(() => mountSpy(), [])` only fires once).
2. Navigating to a different route pattern remounts (mount spy fires twice, different labels).
3. A user-supplied `key` function controls the remount boundary — same return value reuses the instance, different return value remounts.

Also broadened `tests/utilities.tsx`'s `render` helper to accept a real `Navigation` (not just `TestNavigation`, whose `navigate` is a no-op) so tests can actually exercise navigation.

## Test plan

- [x] `pnpm type-check` — clean
- [x] `pnpm lint` — clean
- [x] `pnpm vitest --run` — 150 tests pass, 1 skipped (matching main)
- [x] `pnpm vitest --run packages/preact-router -t 'key'` — 3 new tests pass

## Breaking change

This is a behavior change to the default: apps that relied on the remount-per-navigation side effect (fresh `useState`, `useEffect` running again on same-URL navigations) will see the instance reused instead. Escape hatch for anyone who needs the old behavior: supply `key: () => Math.random()` (or similar).

## Notes

- `pnpm-lock.yaml` picks up a set of `preact ^10.26.0 → ^10.29.0` version bumps for packages whose `package.json` on `main` already specified `^10.29.0`. That inconsistency was pre-existing — any `pnpm install` on `main` surfaces it.
- `@quilted/preact-signals` added as a `devDependency` of `@quilted/preact-router` so the test file can install the Preact↔signals render integration (required for `.value` reads during render to subscribe the component, which is how the test harness observes navigation-driven re-renders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)