### PR TITLE
Default HTMLTemplate serializations + assets into <head>; switch <Serialization> to <script>

### DIFF
--- a/.changeset/odd-yaks-sit.md
+++ b/.changeset/odd-yaks-sit.md
@@ -1,0 +1,19 @@
+---
+'@quilted/preact-browser': patch
+'@quilted/browser': patch
+---
+
+Move `HTMLTemplate` serializations and asset placeholders into `<head>` by default
+
+`HTMLTemplate.Body` previously rendered the `<HTMLTemplate.Serializations />` and `<HTMLTemplate.Assets />` placeholders directly inside `<body>`, ahead of the app content. That layout produced a Safari-specific flash of unstyled content on initial paint: body-positioned `<link rel=stylesheet>` (even with `blocking="render"`) didn't reliably stop the parser from committing the body content that preceded them.
+
+The default placement is now:
+
+- `HTMLTemplate.Head` renders title/links/metas, then `<HTMLTemplate.Serializations />`, then the three `<HTMLTemplate.Assets />` placeholders (entry, async, preload) — same order `HTMLTemplate.Body` used to use.
+- `HTMLTemplate.Body` renders only the wrapper + `<HTMLTemplate.Content />`.
+
+Stylesheet links land in `<head>`, where they block initial render the standards-correct way; `Link: rel=preload` HTTP headers and the in-document `<link>` tags now consistently target the same location, so the preload scanner picks the same URLs both ways.
+
+Apps that already pass a custom `head={…}` or `body={…}` to `HTMLTemplate` aren't affected — the change is in the default content of `HTMLTemplateHead` / `HTMLTemplateBody`, which only takes effect when the `children` prop on those components isn't provided.
+
+`<Serialization>` now renders as `<script type="quilt/serialization" data-name=...>JSON</script>` instead of `<browser-serialization name=... content=...>`. The script form is required for the head positioning above: `<browser-serialization>` is unknown to the HTML parser, which treats it as flow content; encountering one in `<head>` would close `<head>` and start `<body>`, dragging the asset placeholders out of the head with it. The script form is parser-safe in both head and body, doesn't execute (the type isn't a recognized JS MIME), and the JSON payload escapes "<" to its unicode form so a `</script>` inside a serialized value can't terminate the tag. The client-side reader (`BrowserSerializations`) was updated to match; the legacy `BrowserSerializationElement` custom-element class still works for anyone defining it programmatically (the read path falls back to its `name` / `content` attributes).

--- a/packages/browser/source/browser.ts
+++ b/packages/browser/source/browser.ts
@@ -226,6 +226,15 @@ const HTMLElement: typeof globalThis.HTMLElement =
 
 const DEFAULT_SERIALIZATION_ELEMENT_NAME = 'browser-serialization';
 
+// SSR now writes serializations as `<script type="quilt/serialization" data-name=…>JSON</script>`
+// instead of as `<browser-serialization>` custom elements. The script form is
+// parser-safe in `<head>` (where the default `HTMLTemplate` now puts these),
+// and avoids a Safari quirk where unknown body elements ahead of the first
+// `<link rel=stylesheet>` can flash unstyled content even with
+// `blocking="render"`. The legacy `BrowserSerializationElement` class below
+// keeps working for anyone who still defines it programmatically.
+const SERIALIZATION_SCRIPT_SELECTOR = 'script[type="quilt/serialization"]';
+
 export class BrowserSerializationElement<T = unknown> extends HTMLElement {
   static define(name: string = DEFAULT_SERIALIZATION_ELEMENT_NAME) {
     customElements.define(name, this);
@@ -323,7 +332,7 @@ export class BrowserSerializations {
             for (const node of mutation.addedNodes) {
               if (node.nodeType === Node.ELEMENT_NODE) {
                 for (const serialization of (node as Element).querySelectorAll(
-                  DEFAULT_SERIALIZATION_ELEMENT_NAME,
+                  SERIALIZATION_SCRIPT_SELECTOR,
                 )) {
                   updates.set(...serializationEntryFromNode(serialization));
                 }
@@ -350,19 +359,23 @@ export class BrowserSerializations {
 
 function getSerializationsFromDocument() {
   return Array.from(
-    document.querySelectorAll<HTMLElement>(DEFAULT_SERIALIZATION_ELEMENT_NAME),
+    document.querySelectorAll<HTMLElement>(SERIALIZATION_SCRIPT_SELECTOR),
   ).map(serializationEntryFromNode);
 }
 
 function serializationEntryFromNode<T = unknown>(node: Element): [string, T] {
-  return [
-    node.getAttribute('name') ?? '_default',
-    getSerializedFromNode(node) as any,
-  ];
+  // Script form carries the name on `data-name` and the payload as text content;
+  // fall back to the legacy `name` / `content` attributes so a
+  // `<browser-serialization>` (e.g. produced by `BrowserSerializationElement`)
+  // still parses correctly.
+  const name =
+    node.getAttribute('data-name') ?? node.getAttribute('name') ?? '_default';
+  return [name, getSerializedFromNode(node) as any];
 }
 
 function getSerializedFromNode<T = unknown>(node: Element): T | undefined {
-  const value = node.getAttribute('content');
+  const value =
+    node.tagName === 'SCRIPT' ? node.textContent : node.getAttribute('content');
 
   try {
     return value ? (decode(JSON.parse(value)) as T) : undefined;

--- a/packages/preact-browser/source/server/components/HTMLTemplate.tsx
+++ b/packages/preact-browser/source/server/components/HTMLTemplate.tsx
@@ -53,6 +53,29 @@ export function HTMLTemplateHead({
       {(metas ?? browserResponse?.metas.value)?.map((meta) => (
         <meta {...(meta as any)} />
       ))}
+      {/*
+        Serializations and asset placeholders default into <head>, not <body>,
+        for two reasons:
+
+        1. Stylesheet links work most reliably as render-blocking when they're
+           in <head>. Body-positioned `<link rel=stylesheet>` (even with
+           `blocking="render"`) can flash unstyled content in Safari when
+           there's any preceding body content the parser has already started
+           to commit. Putting them in <head> sidesteps that entirely.
+        2. The HTTP `Link: rel=preload` headers `renderAppToHTMLResponse`
+           emits for entry assets are most useful when the corresponding
+           `<link>` tags are also in <head>; the preload scanner picks them
+           up before any body content streams in.
+
+        The order — serializations, then entry assets, then async, then
+        preload — matches what `HTMLTemplateBody` used to render so existing
+        behavior around hydration timing and `browser.assets` discovery is
+        preserved.
+      */}
+      <HTMLTemplateSerializations />
+      <HTMLTemplateAssets />
+      <HTMLTemplateAssets async />
+      <HTMLTemplateAssets preload />
     </>
   );
 
@@ -73,24 +96,20 @@ export function HTMLTemplateBody({
 }: RenderableProps<HTMLTemplateBodyProps>) {
   const browserResponse = useBrowserResponse();
 
-  const bodyContent = children ?? (
-    <>
-      <HTMLTemplateSerializations />
-      <HTMLTemplateAssets />
-      <HTMLTemplateAssets async />
-      <HTMLTemplateAssets preload />
-
-      {wrapper ? (
-        <div
-          {...(typeof wrapper === 'boolean' ? DEFAULT_WRAPPER_PROPS : wrapper)}
-        >
-          <HTMLTemplateContent />
-        </div>
-      ) : (
+  // Serializations and asset placeholders moved to `HTMLTemplateHead`;
+  // see the comment there. The body now defaults to just the wrapper +
+  // content placeholder.
+  const bodyContent =
+    children ??
+    (wrapper ? (
+      <div
+        {...(typeof wrapper === 'boolean' ? DEFAULT_WRAPPER_PROPS : wrapper)}
+      >
         <HTMLTemplateContent />
-      )}
-    </>
-  );
+      </div>
+    ) : (
+      <HTMLTemplateContent />
+    ));
 
   return (
     <body {...browserResponse.bodyAttributes.value} {...rest}>

--- a/packages/preact-browser/source/server/components/Serialization.tsx
+++ b/packages/preact-browser/source/server/components/Serialization.tsx
@@ -13,9 +13,34 @@ export function Serialization({
   content: unknown;
 }) {
   if (!useBrowserEffectsAreActive()) {
+    // Render the SSR payload as a non-executing <script> tag instead of an
+    // unknown custom element. Two reasons:
+    //
+    // 1. The default `HTMLTemplate` now puts serializations in `<head>`, and
+    //    the HTML parser treats unknown elements (like `<browser-serialization>`)
+    //    as flow content. Encountering one in the head closes `<head>` and
+    //    opens `<body>`, so the serializations would silently relocate and
+    //    drag the asset placeholders that follow them out with them. A
+    //    `<script>` element is metadata-content and stays in the head.
+    // 2. In Safari (and to a lesser extent other engines) a stretch of unknown
+    //    body elements arriving before any `<link rel=stylesheet>` flips the
+    //    parser into "the body has started" mode, and `blocking="render"`
+    //    on links that follow doesn't reliably block the paint of the
+    //    elements that came before.
+    //
+    // The script's `type` is non-executing (the browser only runs `text/javascript`
+    // / module scripts), so the JSON body is treated as plain text. Every "<"
+    // is escaped to its unicode form so a literal "</script>" inside a
+    // serialized value can't terminate the tag (and HTML comment / CDATA
+    // prefixes can't sneak in either).
     return (
-      // @ts-expect-error a custom element that I don’t want to define,
-      <browser-serialization name={name} content={JSON.stringify(content)} />
+      <script
+        type="quilt/serialization"
+        data-name={name}
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify(content).replace(/</g, '\\u003c'),
+        }}
+      />
     );
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -343,8 +343,8 @@ importers:
         specifier: ^26.0.0
         version: 26.0.0
       preact:
-        specifier: ^10.26.0
-        version: 10.26.0
+        specifier: ^10.29.0
+        version: 10.29.0
       react:
         specifier: npm:@quilted/react@^19.0.0
         version: '@quilted/react@19.0.0'
@@ -361,8 +361,8 @@ importers:
         specifier: ^4.8.0
         version: 4.8.5
       preact:
-        specifier: ^10.26.0
-        version: 10.26.0
+        specifier: ^10.29.0
+        version: 10.29.0
       react:
         specifier: npm:@quilted/react@^19.0.0
         version: '@quilted/react@19.0.0'
@@ -388,8 +388,8 @@ importers:
         specifier: ^26.0.0
         version: 26.0.0
       preact:
-        specifier: ^10.26.0
-        version: 10.26.0
+        specifier: ^10.29.0
+        version: 10.29.0
       react:
         specifier: npm:@quilted/react@^19.0.0
         version: '@quilted/react@19.0.0'
@@ -427,8 +427,8 @@ importers:
         specifier: ^26.0.0
         version: 26.0.0
       preact:
-        specifier: ^10.26.0
-        version: 10.26.0
+        specifier: ^10.29.0
+        version: 10.29.0
       react:
         specifier: npm:@quilted/react@^19.0.0
         version: '@quilted/react@19.0.0'
@@ -455,7 +455,7 @@ importers:
     devDependencies:
       '@quilted/quilt':
         specifier: ^0.9.0
-        version: 0.9.0(@preact/signals-core@1.8.0)(graphql@16.8.1)(preact@10.26.0)(prettier@3.5.1)(vitest@3.2.4(@types/node@22.13.4)(jsdom@26.0.0)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 0.9.0(@preact/signals-core@1.14.0)(graphql@16.8.1)(preact@10.29.0)(prettier@3.5.1)(vitest@3.2.4(@types/node@22.13.4)(jsdom@26.0.0)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
 
   packages/create/templates/workspace:
     devDependencies:
@@ -467,7 +467,7 @@ importers:
         version: 0.4.2
       '@quilted/vite':
         specifier: ^0.3.0
-        version: 0.3.2(@babel/template@7.26.9)(@babel/traverse@7.26.9)(@babel/types@7.26.9)(@types/babel__core@7.20.5)(preact@10.26.0)(rollup@4.46.2)(vite@7.1.1(@types/node@22.13.4)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.2.4(@types/node@22.13.4)(jsdom@26.0.0)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+        version: 0.3.2(@babel/template@7.26.9)(@babel/traverse@7.26.9)(@babel/types@7.26.9)(@types/babel__core@7.20.5)(preact@10.29.0)(rollup@4.46.2)(vite@7.1.1(@types/node@22.13.4)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.2.4(@types/node@22.13.4)(jsdom@26.0.0)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       prettier:
         specifier: ^3.3.0
         version: 3.5.1
@@ -7165,7 +7165,7 @@ snapshots:
 
   '@quilted/events@2.1.3':
     dependencies:
-      '@preact/signals-core': 1.8.0
+      '@preact/signals-core': 1.14.0
 
   '@quilted/graphql@3.3.9':
     dependencies:
@@ -7192,117 +7192,117 @@ snapshots:
     dependencies:
       '@quilted/events': 2.1.3
 
-  '@quilted/preact-async@0.1.21(preact@10.26.0)':
+  '@quilted/preact-async@0.1.21(preact@10.29.0)':
     dependencies:
       '@quilted/async': 0.4.23
-      '@quilted/preact-browser': 0.2.5(preact@10.26.0)
-      '@quilted/preact-context': 0.1.3(preact@10.26.0)
-      '@quilted/preact-signals': 0.1.2(preact@10.26.0)
+      '@quilted/preact-browser': 0.2.5(preact@10.29.0)
+      '@quilted/preact-context': 0.1.3(preact@10.29.0)
+      '@quilted/preact-signals': 0.1.2(preact@10.29.0)
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
 
-  '@quilted/preact-browser@0.2.5(preact@10.26.0)':
+  '@quilted/preact-browser@0.2.5(preact@10.29.0)':
     dependencies:
       '@quilted/assets': 0.1.10
       '@quilted/browser': 0.2.2
       '@quilted/http': 0.3.0
-      '@quilted/preact-context': 0.1.3(preact@10.26.0)
+      '@quilted/preact-context': 0.1.3(preact@10.29.0)
       '@quilted/signals': 0.2.3
-      preact-render-to-string: 6.5.13(preact@10.26.0)
+      preact-render-to-string: 6.6.6(preact@10.29.0)
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
 
-  '@quilted/preact-context@0.1.3(preact@10.26.0)':
+  '@quilted/preact-context@0.1.3(preact@10.29.0)':
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
 
-  '@quilted/preact-graphql@0.1.8(preact@10.26.0)':
+  '@quilted/preact-graphql@0.1.8(preact@10.29.0)':
     dependencies:
       '@quilted/graphql': 3.3.9
-      '@quilted/preact-async': 0.1.21(preact@10.26.0)
-      '@quilted/preact-context': 0.1.3(preact@10.26.0)
-      '@quilted/preact-signals': 0.1.2(preact@10.26.0)
+      '@quilted/preact-async': 0.1.21(preact@10.29.0)
+      '@quilted/preact-context': 0.1.3(preact@10.29.0)
+      '@quilted/preact-signals': 0.1.2(preact@10.29.0)
       '@quilted/useful-types': 2.0.0
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
 
-  '@quilted/preact-localize@0.4.0(preact@10.26.0)':
+  '@quilted/preact-localize@0.4.0(preact@10.29.0)':
     dependencies:
       '@quilted/localize': 0.2.1
-      '@quilted/preact-browser': 0.2.5(preact@10.26.0)
-      '@quilted/preact-context': 0.1.3(preact@10.26.0)
-      '@quilted/preact-router': 0.2.13(preact@10.26.0)
+      '@quilted/preact-browser': 0.2.5(preact@10.29.0)
+      '@quilted/preact-context': 0.1.3(preact@10.29.0)
+      '@quilted/preact-router': 0.2.13(preact@10.29.0)
       '@quilted/signals': 0.2.3
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
 
-  '@quilted/preact-performance@0.1.1(preact@10.26.0)':
+  '@quilted/preact-performance@0.1.1(preact@10.29.0)':
     dependencies:
       '@quilted/performance': 0.2.1
-      '@quilted/preact-context': 0.1.3(preact@10.26.0)
+      '@quilted/preact-context': 0.1.3(preact@10.29.0)
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
 
-  '@quilted/preact-router@0.2.13(preact@10.26.0)':
+  '@quilted/preact-router@0.2.13(preact@10.29.0)':
     dependencies:
       '@quilted/async': 0.4.23
       '@quilted/http': 0.3.0
-      '@quilted/preact-async': 0.1.21(preact@10.26.0)
-      '@quilted/preact-browser': 0.2.5(preact@10.26.0)
-      '@quilted/preact-context': 0.1.3(preact@10.26.0)
-      '@quilted/preact-performance': 0.1.1(preact@10.26.0)
+      '@quilted/preact-async': 0.1.21(preact@10.29.0)
+      '@quilted/preact-browser': 0.2.5(preact@10.29.0)
+      '@quilted/preact-context': 0.1.3(preact@10.29.0)
+      '@quilted/preact-performance': 0.1.1(preact@10.29.0)
       '@quilted/routing': 0.4.3
       '@quilted/signals': 0.2.3
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
 
-  '@quilted/preact-signals@0.1.2(preact@10.26.0)':
+  '@quilted/preact-signals@0.1.2(preact@10.29.0)':
     dependencies:
-      '@preact/signals': 2.0.1(preact@10.26.0)
+      '@preact/signals': 2.8.2(preact@10.29.0)
       '@quilted/signals': 0.2.3
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
 
-  '@quilted/preact-testing@0.1.8(preact@10.26.0)':
+  '@quilted/preact-testing@0.1.8(preact@10.29.0)':
     dependencies:
       jest-matcher-utils: 27.5.1
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
 
-  '@quilted/preact-workers@0.2.1(@preact/signals-core@1.8.0)(preact@10.26.0)':
+  '@quilted/preact-workers@0.2.1(@preact/signals-core@1.14.0)(preact@10.29.0)':
     dependencies:
-      '@quilted/workers': 0.5.1(@preact/signals-core@1.8.0)
+      '@quilted/workers': 0.5.1(@preact/signals-core@1.14.0)
     optionalDependencies:
-      preact: 10.26.0
+      preact: 10.29.0
     transitivePeerDependencies:
       - '@preact/signals-core'
 
-  '@quilted/quilt@0.9.0(@preact/signals-core@1.8.0)(graphql@16.8.1)(preact@10.26.0)(prettier@3.5.1)(vitest@3.2.4(@types/node@22.13.4)(jsdom@26.0.0)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@quilted/quilt@0.9.0(@preact/signals-core@1.14.0)(graphql@16.8.1)(preact@10.29.0)(prettier@3.5.1)(vitest@3.2.4(@types/node@22.13.4)(jsdom@26.0.0)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@quilted/assets': 0.1.10
       '@quilted/async': 0.4.23
       '@quilted/events': 2.1.3
       '@quilted/graphql': 3.3.9
       '@quilted/hono': 0.2.0
-      '@quilted/preact-async': 0.1.21(preact@10.26.0)
-      '@quilted/preact-browser': 0.2.5(preact@10.26.0)
-      '@quilted/preact-context': 0.1.3(preact@10.26.0)
-      '@quilted/preact-graphql': 0.1.8(preact@10.26.0)
-      '@quilted/preact-localize': 0.4.0(preact@10.26.0)
-      '@quilted/preact-performance': 0.1.1(preact@10.26.0)
-      '@quilted/preact-router': 0.2.13(preact@10.26.0)
-      '@quilted/preact-signals': 0.1.2(preact@10.26.0)
-      '@quilted/preact-testing': 0.1.8(preact@10.26.0)
-      '@quilted/preact-workers': 0.2.1(@preact/signals-core@1.8.0)(preact@10.26.0)
+      '@quilted/preact-async': 0.1.21(preact@10.29.0)
+      '@quilted/preact-browser': 0.2.5(preact@10.29.0)
+      '@quilted/preact-context': 0.1.3(preact@10.29.0)
+      '@quilted/preact-graphql': 0.1.8(preact@10.29.0)
+      '@quilted/preact-localize': 0.4.0(preact@10.29.0)
+      '@quilted/preact-performance': 0.1.1(preact@10.29.0)
+      '@quilted/preact-router': 0.2.13(preact@10.29.0)
+      '@quilted/preact-signals': 0.1.2(preact@10.29.0)
+      '@quilted/preact-testing': 0.1.8(preact@10.29.0)
+      '@quilted/preact-workers': 0.2.1(@preact/signals-core@1.14.0)(preact@10.29.0)
       '@quilted/react': 19.0.0
       '@quilted/react-dom': 19.0.1
       '@quilted/signals': 0.2.3
-      '@quilted/threads': 4.0.1(@preact/signals-core@1.8.0)
+      '@quilted/threads': 4.0.1(@preact/signals-core@1.14.0)
       jest-matcher-utils: 29.7.0
-      preact-render-to-string: 6.5.13(preact@10.26.0)
+      preact-render-to-string: 6.6.6(preact@10.29.0)
     optionalDependencies:
       graphql: 16.8.1
-      preact: 10.26.0
+      preact: 10.29.0
       prettier: 3.5.1
       vitest: 3.2.4(@types/node@22.13.4)(jsdom@26.0.0)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0)
     transitivePeerDependencies:
@@ -7313,13 +7313,13 @@ snapshots:
     dependencies:
       '@types/react': 19.0.10
       '@types/react-dom': 19.0.4(@types/react@19.0.10)
-      preact: 10.26.0
-      preact-render-to-string: 6.5.13(preact@10.26.0)
+      preact: 10.29.0
+      preact-render-to-string: 6.6.6(preact@10.29.0)
 
   '@quilted/react@19.0.0':
     dependencies:
       '@types/react': 19.0.10
-      preact: 10.26.0
+      preact: 10.29.0
 
   '@quilted/rollup@0.4.6(@babel/template@7.26.9)(@babel/traverse@7.26.9)(@babel/types@7.26.9)(@types/babel__core@7.20.5)(rollup@4.46.2)':
     dependencies:
@@ -7369,23 +7369,23 @@ snapshots:
 
   '@quilted/signals@0.2.3':
     dependencies:
-      '@preact/signals-core': 1.8.0
+      '@preact/signals-core': 1.14.0
       '@quilted/events': 2.1.3
 
-  '@quilted/threads@4.0.1(@preact/signals-core@1.8.0)':
+  '@quilted/threads@4.0.1(@preact/signals-core@1.14.0)':
     dependencies:
       '@quilted/events': 2.1.3
     optionalDependencies:
-      '@preact/signals-core': 1.8.0
+      '@preact/signals-core': 1.14.0
 
   '@quilted/typescript@0.4.2': {}
 
   '@quilted/useful-types@2.0.0': {}
 
-  '@quilted/vite@0.3.2(@babel/template@7.26.9)(@babel/traverse@7.26.9)(@babel/types@7.26.9)(@types/babel__core@7.20.5)(preact@10.26.0)(rollup@4.46.2)(vite@7.1.1(@types/node@22.13.4)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.2.4(@types/node@22.13.4)(jsdom@26.0.0)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
+  '@quilted/vite@0.3.2(@babel/template@7.26.9)(@babel/traverse@7.26.9)(@babel/types@7.26.9)(@types/babel__core@7.20.5)(preact@10.29.0)(rollup@4.46.2)(vite@7.1.1(@types/node@22.13.4)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))(vitest@3.2.4(@types/node@22.13.4)(jsdom@26.0.0)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))':
     dependencies:
       '@babel/core': 7.26.9
-      '@prefresh/vite': 2.4.7(preact@10.26.0)(vite@7.1.1(@types/node@22.13.4)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
+      '@prefresh/vite': 2.4.7(preact@10.29.0)(vite@7.1.1(@types/node@22.13.4)(lightningcss@1.29.1)(terser@5.39.0)(tsx@4.19.2)(yaml@2.7.0))
       '@quilted/babel': 0.2.4(@babel/core@7.26.9)(@babel/template@7.26.9)(@babel/traverse@7.26.9)(@babel/types@7.26.9)
       '@quilted/hono': 0.2.0
       '@quilted/rollup': 0.4.6(@babel/template@7.26.9)(@babel/traverse@7.26.9)(@babel/types@7.26.9)(@types/babel__core@7.20.5)(rollup@4.46.2)
@@ -7402,9 +7402,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@quilted/workers@0.5.1(@preact/signals-core@1.8.0)':
+  '@quilted/workers@0.5.1(@preact/signals-core@1.14.0)':
     dependencies:
-      '@quilted/threads': 4.0.1(@preact/signals-core@1.8.0)
+      '@quilted/threads': 4.0.1(@preact/signals-core@1.14.0)
     transitivePeerDependencies:
       - '@preact/signals-core'
 

--- a/tests/e2e/assets.test.ts
+++ b/tests/e2e/assets.test.ts
@@ -245,7 +245,13 @@ describe('app builds', () => {
               const request = c.req.raw;
 
               const response = await renderToHTMLResponse(
-                <HTMLTemplate title="Inline CSS test">
+                <HTMLTemplate
+                  head={
+                    <HTMLTemplate.Head>
+                      <title>Inline CSS test</title>
+                    </HTMLTemplate.Head>
+                  }
+                >
                   <HTMLTemplate.Assets name="./inline.css" />
                 </HTMLTemplate>,
                 {request, assets},
@@ -268,7 +274,9 @@ describe('app builds', () => {
         // Minified verison of the source above
         expect(content).toBe(`body{color:#fff;background-color:#000}`);
 
-        // No scripts should be loaded
+        // No scripts should be loaded — the custom <head> above suppresses
+        // the default asset placeholders that would otherwise render the
+        // app's entry script.
         const scripts = await page.$$('script');
         expect(scripts).toHaveLength(0);
       });

--- a/tests/e2e/graphql.test.ts
+++ b/tests/e2e/graphql.test.ts
@@ -84,9 +84,8 @@ describe('graphql', () => {
     expect(greetingText).toBe('Hello from GraphQL!');
 
     // 2. Verify the GraphQL cache serialization is in the DOM
-    const serialization = await page.getAttribute(
-      'browser-serialization[name="quilt:graphql"]',
-      'content',
+    const serialization = await page.textContent(
+      'script[type="quilt/serialization"][data-name="quilt:graphql"]',
     );
     expect(serialization).toBeTruthy();
     expect(serialization).toContain('Hello from GraphQL!');


### PR DESCRIPTION
## Summary

`HTMLTemplate.Body` used to render `<HTMLTemplate.Serializations />` and the three `<HTMLTemplate.Assets />` placeholders (entry, async, preload) directly inside `<body>`, ahead of the app content. That layout caused a Safari-specific flash of unstyled content on initial paint:

- The serializations element (`<browser-serialization>`) is unknown to the HTML parser, so a stretch of these in the body before the first `<link rel=stylesheet>` would commit "the body has started rendering" — and `blocking="render"` on the links that arrived afterward didn't reliably block the paint of the elements that came before. Even with `blocking="render"`, Safari intermittently flashed the SSR'd content unstyled.
- The HTTP `Link: rel=preload` headers `renderAppToHTMLResponse` already emits for entry assets are best paired with `<link>` tags that live in `<head>`; the preload scanner picks them up before any body content streams in.

This PR moves the placeholders into `HTMLTemplate.Head` by default, in the same order the body used to render them, and switches `<Serialization>` from a custom element to a non-executing `<script type="quilt/serialization" …>` so it's parser-safe in `<head>`.

## What changes

**`@quilted/preact-browser` — `HTMLTemplate`**

- `HTMLTemplate.Head`'s default children now include `<HTMLTemplate.Serializations />` and the three `<HTMLTemplate.Assets />` placeholders after the title/links/metas.
- `HTMLTemplate.Body`'s default children shrink to just the wrapper + `<HTMLTemplate.Content />`.
- The relative order — serializations → entry → async → preload — is preserved, so hydration timing and async-asset discovery semantics don't change.

Apps that pass a custom `head={…}` or `body={…}` to `HTMLTemplate` are unaffected. The change is only in the default content of `HTMLTemplateHead` / `HTMLTemplateBody`, which is replaced when callers supply `children`.

**`@quilted/preact-browser` — `<Serialization>` / `@quilted/browser` — `BrowserSerializations`**

- `<Serialization>` now renders as `<script type="quilt/serialization" data-name="…">JSON</script>` instead of `<browser-serialization name="…" content="…" />`. The script form is needed for the head positioning above: `<browser-serialization>` is unknown to the HTML parser and treated as flow content, so encountering one in `<head>` would close `<head>` and start `<body>`, dragging the asset placeholders out of the head with it. `<script>` is metadata content and stays put.
- The script's `type` is non-executing (the browser only runs `text/javascript` / module scripts), and the JSON body has every `<` escaped to `<` so a literal `</script>` inside a serialized value can't terminate the tag.
- `BrowserSerializations` (client-side reader) now queries `script[type="quilt/serialization"]`, reads `data-name` for the id and the script's `textContent` for the JSON. The legacy `BrowserSerializationElement` custom-element class is left in place; the read path falls back to its `name` / `content` attributes so anyone using it programmatically is unaffected.

## Compatibility notes

- Default rendering layout shifts elements from `<body>` to `<head>`. Apps that visually inspect the HTML output (snapshot tests, etc.) will see the shift.
- Anyone reading serializations via `document.querySelectorAll('browser-serialization')` outside of `BrowserSerializations` would no longer find them — they're now `script[type="quilt/serialization"]`. I doubt this is common in practice but worth flagging.
- Apps already passing custom `head={…}` / `body={…}` props are unchanged.

## Test plan

- [ ] Existing tests pass.
- [ ] On a sample app, verify the HTML output now has serializations + asset `<link>` / `<script>` tags in `<head>`, and the body contains only the content wrapper.
- [ ] Verify in Safari that the homepage paints fully styled (no FOUC) on a cold cache.
- [ ] Verify Chrome/Firefox have no regressions (paint timing, hydration, etc.).