### PR TITLE
Fix `useRoutes` matching a stale route tree when the route set changes

### DIFF
--- a/.changeset/preact-router-stale-route-tree.md
+++ b/.changeset/preact-router-stale-route-tree.md
@@ -1,0 +1,14 @@
+---
+'@quilted/preact-router': patch
+---
+
+Fixed `useRoutes` rendering a stale route tree after the active set of routes changes
+
+When the array of routes passed to `useRoutes` changed in place — for example an app that swaps its whole route tree based on the current tenant/scope rather than reloading — the hook kept matching against the tree it captured on its first render, so a navigation that needed the new tree fell through to whatever the old tree matched (often a catch-all "not found"). A full page reload fixed it because that remounted the hook with the correct tree.
+
+Two causes, both fixed:
+
+- `useRoutes` memoised its matching `computed` with only `[navigation, parentEntry]` as dependencies, so the closure pinned the `routes`/`context` from first render. They're now dependencies, so the matcher re-runs against the current tree.
+- `RouterNavigationCache#match` cached the matched stack keyed solely by navigation request id, ignoring the `routes` argument — so even once a fresh match ran, it returned the stale cached stack for that navigation. The cache entry now records the route tree it was produced from and is only reused when the same tree is passed back.
+
+Consumers that pass a new `routes` array every render should memoise it (as is conventional for hook inputs) to avoid re-matching on every render.

--- a/packages/preact-router/source/Navigation.ts
+++ b/packages/preact-router/source/Navigation.ts
@@ -375,7 +375,11 @@ export class RouterNavigationCache {
   #entryCache = new Map<string, RouteNavigationEntry<any, any, any>>();
   #matchCache = new Map<
     string,
-    readonly RouteNavigationEntry<any, any, any>[]
+    {
+      routes: readonly RouteDefinition<any, any, any>[];
+      // Mutable to match `routeStack` below; the matcher fills it by push.
+      stack: RouteNavigationEntry<any, any, any>[];
+    }
   >();
 
   constructor(
@@ -409,17 +413,20 @@ export class RouterNavigationCache {
     if (parent) matchID += `@${stringifyKey(parent.key)}`;
 
     if (!this.disabled) {
-      const cached = this.#matchCache.get(matchID) as
-        | RouteNavigationEntry<any, any, any>[]
-        | undefined;
-      if (cached) {
-        return cached;
+      const cached = this.#matchCache.get(matchID);
+      // Only reuse a cached match when it came from the *same* route tree. The
+      // active tree can be swapped in place for a given navigation (e.g. a
+      // tenant/scope change that selects a different set of routes), and keying
+      // solely by request id would otherwise pin the entry to the stale tree
+      // and mis-match the URL against it.
+      if (cached && cached.routes === routes) {
+        return cached.stack;
       }
     }
 
     let routeStack: RouteNavigationEntry<any, any, any>[] = [];
     if (!this.disabled) {
-      this.#matchCache.set(matchID, routeStack);
+      this.#matchCache.set(matchID, {routes, stack: routeStack});
     }
 
     const base = this.#base;

--- a/packages/preact-router/source/hooks/routes.tsx
+++ b/packages/preact-router/source/hooks/routes.tsx
@@ -34,7 +34,10 @@ export function useRoutes<Context = unknown>(
 
       return matched;
     });
-  }, [navigation, parentEntry]);
+    // Include `routes`/`context` so a route tree that is swapped in place
+    // (e.g. a navigation that changes which set of routes is active) re-matches
+    // against the new tree instead of the one captured when this hook first ran.
+  }, [navigation, parentEntry, routes, context]);
 
   return (
     <Suspense fallback={null}>


### PR DESCRIPTION
## Problem

`useRoutes` keeps matching against the route tree it captured on its **first render**. An app that swaps its whole route tree in place — e.g. one host serving different trees per tenant/scope, switched via a signal rather than a page reload — navigates into the new scope, but the matcher still runs the *old* tree, so the URL falls through to whatever that tree matched (typically a catch-all "not found"). A full page reload "fixes" it only because it remounts the hook with the correct tree.

Concretely this surfaced as a post-sign-in 404: re-auth on the admin host (unscoped tree) → SPA hop to a scoped `/@handle` URL → the frozen unscoped tree has no match → catch-all 404, even though the URL and chrome are correct.

## Root cause

Two compounding bugs:

1. **`useRoutes`** memoised its matching `computed` with deps `[navigation, parentEntry]`, so the closure pinned `routes`/`context` from the first render — later tree swaps were ignored.
2. **`RouterNavigationCache#match`** cached the matched stack keyed solely by navigation `request.id`, ignoring the `routes` argument. So even once `useRoutes` was fixed to re-match, the cache returned the stale stack computed under the old tree for that navigation.

## Fix

- Add `routes`/`context` to the `useRoutes` memo dependencies so the matcher re-runs when the active tree changes.
- Record the route tree on each match-cache entry and only reuse it when the same tree is passed back.

Consumers that build a new `routes` array every render should memoise it (conventional for hook inputs) to avoid re-matching each render.

A changeset is included (`patch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)