### PR TITLE
Add a `source` option to the `graphql()` build feature

### DIFF
--- a/.changeset/graphql-module-source-option.md
+++ b/.changeset/graphql-module-source-option.md
@@ -1,0 +1,5 @@
+---
+'@quilted/rollup': minor
+---
+
+Added a `source` option to the `graphql()` build feature. Setting `source: false` omits the operation source from the transformed `.graphql` modules — each module then contains only the operation's `id`, `type`, and `name`, keeping query text out of your JavaScript bundles entirely. This is designed for "persisted" GraphQL operations: pair it with the existing `manifest` option (which still receives the full source for every operation, so a server can map `id` back to the executable document) and with the `source` option of `createGraphQLFetch()` (which omits the missing source from requests). Fragment-only documents keep their source regardless, since they only exist at runtime to be inlined into the operations that `#import` them.

--- a/packages/rollup/source/features/graphql.ts
+++ b/packages/rollup/source/features/graphql.ts
@@ -11,11 +11,40 @@ import {
 } from './graphql/transform.ts';
 
 export interface GraphQLOptions {
+  /**
+   * Whether to write a manifest mapping each operation's `id` (a SHA-256
+   * hash of its normalized source) to its source text. Pass `true` to write
+   * the manifest to `manifests/graphql.json`, or a string to control the
+   * path. The manifest is the artifact a server consumes to execute
+   * "persisted" operations, where clients send only the operation's `id`.
+   */
   manifest?: string | boolean;
   addTypename?: boolean;
+
+  /**
+   * Whether the transformed `.graphql` modules include the operation's
+   * `source` text. Defaults to `true`.
+   *
+   * Set this to `false` for builds using "persisted" GraphQL operations:
+   * each emitted module then contains only the operation's `id`, `type`,
+   * and `name`, keeping the query text out of the resulting JavaScript
+   * bundles entirely. Pair this with the `manifest` option, which still
+   * receives the full source for every operation (so your server can map
+   * `id` back to the executable document), and with the `source` option of
+   * `createGraphQLFetch()`, which omits the missing source from requests.
+   *
+   * Documents containing only fragments keep their source regardless of
+   * this option — they can't be executed on their own, and only exist at
+   * runtime to be inlined into the operations that `#import` them.
+   */
+  source?: boolean;
 }
 
-export function graphql({manifest, addTypename}: GraphQLOptions = {}): Plugin {
+export function graphql({
+  manifest,
+  addTypename,
+  source: includeSource = true,
+}: GraphQLOptions = {}): Plugin {
   const shouldWriteManifest = Boolean(manifest);
   const manifestPath =
     typeof manifest === 'string' ? manifest : `manifests/graphql.json`;
@@ -49,9 +78,17 @@ export function graphql({manifest, addTypename}: GraphQLOptions = {}): Plugin {
         {addTypename},
       );
 
+      // When the operation source is omitted from the module, the manifest
+      // (attached to module meta below) still carries it, so the persisted
+      // operation map always contains the executable document.
+      const moduleContent =
+        includeSource || document.type == null
+          ? document
+          : {id: document.id, type: document.type, name: document.name};
+
       return {
         code: `export default JSON.parse(${JSON.stringify(
-          JSON.stringify(document),
+          JSON.stringify(moduleContent),
         )})`,
         meta: shouldWriteManifest
           ? {

--- a/packages/rollup/source/features/tests/graphql.test.ts
+++ b/packages/rollup/source/features/tests/graphql.test.ts
@@ -1,0 +1,175 @@
+import {createHash} from 'node:crypto';
+import * as path from 'node:path';
+import {tmpdir} from 'node:os';
+import {mkdtemp, rm, writeFile} from 'node:fs/promises';
+
+import {describe, it, expect} from 'vitest';
+
+import {graphql, type GraphQLOptions} from '../graphql.ts';
+
+const QUERY = `
+  query Greeting($name: String) {
+    greeting(name: $name)
+  }
+`;
+
+const FRAGMENTS = `
+  fragment PersonName on Person {
+    name
+  }
+`;
+
+describe('graphql()', () => {
+  it('transforms a .graphql module into an operation with a hashed id and minified source', async () => {
+    const operation = await transformGraphQLModule(QUERY);
+
+    expect(operation).toMatchObject({
+      type: 'query',
+      name: 'Greeting',
+      source: 'query Greeting($name:String){greeting(name:$name)}',
+    });
+    expect(operation.id).toBe(sha256(operation.source!));
+  });
+
+  describe('source', () => {
+    it('omits the source from the transformed module when `source: false`', async () => {
+      const operation = await transformGraphQLModule(QUERY, {source: false});
+
+      expect(operation).toEqual({
+        id: sha256('query Greeting($name:String){greeting(name:$name)}'),
+        type: 'query',
+        name: 'Greeting',
+      });
+    });
+
+    it('produces the same operation id with and without the source', async () => {
+      const [withSource, withoutSource] = await Promise.all([
+        transformGraphQLModule(QUERY),
+        transformGraphQLModule(QUERY, {source: false}),
+      ]);
+
+      expect(withoutSource.id).toBe(withSource.id);
+    });
+
+    it('keeps the source of fragment-only documents', async () => {
+      const operation = await transformGraphQLModule(FRAGMENTS, {
+        source: false,
+      });
+
+      expect(operation.source).toBe('fragment PersonName on Person{name}');
+    });
+
+    it('keeps the full operation, including its source, in the module meta used for the manifest', async () => {
+      const {meta} = await transformGraphQL(QUERY, {
+        source: false,
+        manifest: true,
+      });
+
+      expect(meta?.quilt?.graphql).toMatchObject({
+        name: 'Greeting',
+        source: 'query Greeting($name:String){greeting(name:$name)}',
+      });
+    });
+
+    it('resolves #import-ed fragments before omitting the source', async () => {
+      const directory = await mkdtemp(path.join(tmpdir(), 'quilt-graphql-'));
+
+      try {
+        await writeFile(
+          path.join(directory, 'PersonNameFragment.graphql'),
+          FRAGMENTS,
+        );
+
+        // `#import` comments must start at the beginning of a line.
+        const operationSource = [
+          '#import "./PersonNameFragment.graphql"',
+          '',
+          'query Person {',
+          '  person {',
+          '    ...PersonName',
+          '  }',
+          '}',
+        ].join('\n');
+
+        const [withSource, withoutSource] = await Promise.all([
+          transformGraphQLModule(operationSource, undefined, {
+            id: path.join(directory, 'PersonQuery.graphql'),
+          }),
+          transformGraphQLModule(
+            operationSource,
+            {source: false},
+            {id: path.join(directory, 'PersonQuery.graphql')},
+          ),
+        ]);
+
+        expect(withSource.source).toContain('fragment PersonName');
+        expect(withoutSource).toEqual({
+          id: withSource.id,
+          type: 'query',
+          name: 'Person',
+        });
+      } finally {
+        await rm(directory, {recursive: true, force: true});
+      }
+    });
+  });
+});
+
+interface TransformedOperation {
+  id: string;
+  type?: string;
+  name?: string;
+  source?: string;
+}
+
+async function transformGraphQL(
+  code: string,
+  options?: GraphQLOptions,
+  {id = '/project/TestQuery.graphql'}: {id?: string} = {},
+) {
+  const plugin = graphql(options);
+
+  // A minimal stand-in for Rollup's transform plugin context: the hook only
+  // uses `resolve()` and `addWatchFile()` (for `#import`-ed documents).
+  const context = {
+    async resolve(imported: string, importer: string) {
+      return {id: path.resolve(path.dirname(importer), imported)};
+    },
+    addWatchFile() {},
+  };
+
+  const result = await (
+    plugin.transform as unknown as (
+      this: typeof context,
+      code: string,
+      id: string,
+    ) => Promise<{
+      code: string;
+      meta?: {quilt?: {graphql?: TransformedOperation}};
+    }>
+  ).call(context, code, id);
+
+  return result;
+}
+
+async function transformGraphQLModule(
+  code: string,
+  options?: GraphQLOptions,
+  transformOptions?: {id?: string},
+): Promise<TransformedOperation> {
+  const result = await transformGraphQL(code, options, transformOptions);
+
+  const serialized = result.code.match(
+    /^export default JSON\.parse\((.*)\)$/s,
+  )?.[1];
+
+  if (serialized == null) {
+    throw new Error(`Unexpected module content: ${result.code}`);
+  }
+
+  return JSON.parse(JSON.parse(serialized));
+}
+
+function sha256(content: string) {
+  return createHash('sha256').update(content).digest('hex');
+}

--- a/packages/rollup/vite.config.js
+++ b/packages/rollup/vite.config.js
@@ -1,0 +1,6 @@
+import {defineConfig} from 'vite';
+import {quiltPackage} from '@quilted/vite/package';
+
+export default defineConfig({
+  plugins: [quiltPackage()],
+});


### PR DESCRIPTION
## What

Adds a `source?: boolean` option (default `true`) to the `graphql()` feature in `@quilted/rollup`. Setting `source: false` omits the operation source from the transformed `.graphql`/`.gql` modules — each module then contains only the operation's `id`, `type`, and `name`, keeping query text out of JavaScript bundles entirely.

## Why

This is the missing build-side piece for **persisted GraphQL operations**. The other halves already exist:

- the plugin's `manifest` option emits the `id → source` map a server needs to execute operations by id (and still receives the **full** source for every operation when `source: false`, since the manifest is built from module meta rather than the emitted module content);
- `createGraphQLFetch()`'s `source` option omits the source from requests, sending only variables.

With all three, a client bundle carries (and transmits) only content-hash ids while the server holds the documents. We're consuming this downstream in Sessions, which currently does the stripping with a wrapper plugin around `graphql()` (SessionsCode/Sessions#1904) that this option will replace.

Two details worth calling out:

- **Fragment-only documents keep their source** regardless of the option. They can't be executed on their own, and their runtime module only exists to be inlined into the operations that `#import` them.
- The operation `id` is unchanged by the option (it's computed before emission), so ids in a stripped bundle match the ids in the manifest byte-for-byte.

## Tests

Added unit tests for the transform covering the default shape, the stripped shape (and id stability across the two), fragment-only passthrough, manifest meta retention, and `#import` resolution. This also adds the standard `vite.config.js` to `packages/rollup` so its tests run as part of the vitest workspace (it previously had none).

Typecheck and prettier are clean for the touched packages; the only `tsc --build` failures locally are pre-existing in `integrations/trpc` (its `@trpc/*: next` specifiers float to 11.13.0, which renamed `callProcedure`) and untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)