### PR TITLE
Publish via npm trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,6 +18,11 @@ jobs:
     needs: checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
+    permissions:
+      # Mint the OIDC token pnpm exchanges for a short-lived npm token
+      # (npm trusted publishing). Replaces the NPM_TOKEN secret.
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/actions/prepare
@@ -26,4 +31,5 @@ jobs:
       - name: Deploy
         run: pnpm run deploy
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # Emit signed provenance attestations alongside trusted publishing.
+          npm_config_provenance: "true"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,4 +32,4 @@ jobs:
         run: pnpm run deploy
         env:
           # Emit signed provenance attestations alongside trusted publishing.
-          npm_config_provenance: "true"
+          npm_config_provenance: 'true'


### PR DESCRIPTION
## What

Switches the `Deploy` job from token-based npm publishing to **OIDC trusted publishing**, fixing the failed release run ([job log](https://github.com/lemonmade/quilt/actions/runs/27363106114/job/80893486581)).

## Why it was failing

`pnpm publish -r` (pnpm 11) attempts OIDC trusted publishing first, but the job had no `id-token: write` permission:

```
[WARN] Skipped OIDC: ERR_PNPM_ID_TOKEN_GITHUB_WORKFLOW_INCORRECT_PERMISSIONS
[ERR_PNPM_OTP_NON_INTERACTIVE] The registry requires additional authentication...
```

So it fell back to token auth and then asked for an interactive OTP, which can't happen in CI.

## Change

- Add `permissions: { id-token: write, contents: read }` to the `deploy` job so pnpm can mint the OIDC token and exchange it for a short-lived npm token.
- Drop the now-unused `NODE_AUTH_TOKEN: \${{ secrets.NPM_TOKEN }}` wiring.
- Enable `npm_config_provenance` so releases ship signed provenance attestations (every package already has a correct `repository` field with `directory`, so provenance resolves).

## Required out-of-band step (one-time)

Each package needs a GitHub Actions **trusted publisher** registered on npm (repo `lemonmade/quilt`, workflow `deploy.yml`), via the `npm trust` CLI:

\`\`\`bash
for pj in packages/*/package.json; do
  name=\$(jq -r 'select(.private != true) | .name // empty' "\$pj")
  [ -n "\$name" ] || continue
  npm trust github "\$name" --repo lemonmade/quilt --file deploy.yml --allow-publish -y
done
\`\`\`

Until that's configured for a given package, its publish will still fall back to token auth. Once all packages are registered, the `NPM_TOKEN` secret can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)