### PR TITLE
Publish preview versions via OIDC trusted publishing

### DIFF
--- a/.github/workflows/preview-versions.yml
+++ b/.github/workflows/preview-versions.yml
@@ -11,6 +11,11 @@ jobs:
     name: Preview 🔮
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      # Mint the OIDC token pnpm exchanges for a short-lived npm token
+      # (npm trusted publishing). Replaces the NPM_TOKEN secret.
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/actions/prepare
@@ -27,9 +32,14 @@ jobs:
       - uses: ./.github/workflows/actions/type-check-with-cache
       - run: pnpm run build
       - name: Deploy preview versions to NPM
+        # Publish with pnpm (not `changeset publish`) so releases go out over
+        # pnpm's OIDC trusted publishing, matching the main deploy workflow.
+        # `--no-git-checks` is required because `changeset version` dirties the
+        # working tree. GITHUB_TOKEN stays for @changesets/changelog-github,
+        # which hits the GitHub API during `changeset version`.
         run: |
           pnpm changeset version --snapshot preview
-          pnpm changeset publish --tag preview --no-git-tag
+          pnpm publish -r --tag preview --no-git-checks
         env:
+          npm_config_provenance: 'true'
           GITHUB_TOKEN: ${{ secrets.RELEASES_GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Moves the **preview/snapshot** publish path (`preview-versions.yml`) onto npm OIDC trusted publishing, the same way [#943](https://github.com/lemonmade/quilt/pull/943) did for the main `deploy.yml`. This is the last thing tying the repo to the `NPM_TOKEN` secret.

## Changes

- Add `permissions: { id-token: write, contents: read }` to the `preview` job.
- Publish with **`pnpm publish -r --tag preview --no-git-checks`** instead of `pnpm changeset publish`.
  - `changeset publish` shells out to `npm publish`, which would require **npm ≥ 11.5.1** in CI for OIDC to engage. `pnpm publish -r` uses pnpm's own OIDC support (already proven by `deploy.yml`), sidestepping that.
  - `--no-git-checks` because `changeset version --snapshot` leaves the working tree dirty.
- Drop `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`.
- Keep `GITHUB_TOKEN` — `@changesets/changelog-github` calls the GitHub API during `changeset version`.
- Enable `npm_config_provenance`, matching `deploy.yml`.

<details>
<summary>preview-versions.yml diff</summary>

```yaml
 jobs:
   preview:
     ...
     timeout-minutes: 10
+    permissions:
+      id-token: write
+      contents: read
     steps:
       ...
       - name: Deploy preview versions to NPM
         run: |
           pnpm changeset version --snapshot preview
-          pnpm changeset publish --tag preview --no-git-tag
+          pnpm publish -r --tag preview --no-git-checks
         env:
+          npm_config_provenance: 'true'
           GITHUB_TOKEN: ${{ secrets.RELEASES_GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```
</details>

## Required out-of-band step (one-time)

Each package needs a **second** trusted publisher registered on npm, pointing at this workflow file (in addition to the `deploy.yml` one from #943):

\`\`\`bash
for pj in packages/*/package.json; do
  name=\$(jq -r 'select(.private != true) | .name // empty' "\$pj")
  [ -n "\$name" ] || continue
  npm trust github "\$name" --repo lemonmade/quilt --file preview-versions.yml --allow-publish -y
done
\`\`\`

Once both `deploy.yml` and `preview-versions.yml` trusted publishers are configured for all packages, the `NPM_TOKEN` secret can be deleted.

## Note

`snapshot-versions.yml` (the `/snap` PR-comment flow) is currently broken independently of this change — it runs `pnpm run deploy:snapshot`, a script that doesn't exist in the repo. Worth fixing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)