### PR TITLE
vite: declare peer support for Vite 8 and Vitest 4

### DIFF
--- a/packages/quilt/package.json
+++ b/packages/quilt/package.json
@@ -267,7 +267,7 @@
     "graphql": "^16.8.0",
     "preact": "^10.29.0",
     "prettier": "^2.0.0 || ^3.0.0",
-    "vitest": "^2.0.0 || ^3.0.0"
+    "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "graphql": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -58,8 +58,8 @@
     "@quilted/rollup": "workspace:^0.4.6"
   },
   "peerDependencies": {
-    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0",
-    "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0"
+    "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+    "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "vite": {


### PR DESCRIPTION
Widens the peer ranges so downstream workspaces can adopt **Vite 8** (Rolldown) and **Vitest 4** without peer-dependency overrides.

```diff
# packages/vite
- "vite":   "^5.0.0 || ^6.0.0 || ^7.0.0"
+ "vite":   "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
- "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0"
+ "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"

# packages/quilt
- "vitest": "^2.0.0 || ^3.0.0"
+ "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0"
```

## Why peer-range-only

This deliberately does **not** bump quilt's own dev/root/template deps to Vite 8 / Vitest 4 / TS 6. I tried that first (root + template + `@quilted/vite` dev) and `pnpm type-check` surfaced **22 errors** — building `@quilted/vite` against Vite 8 is a real migration, not a version bump:

- **Vite 8 is Rolldown-based.** Its `Plugin` / `PluginContext` come from `rolldown`, but `@quilted/vite` types its plugins against `rollup` (`packages/vite/source/shared/magic-module.ts` imports `PluginContext` from `'rollup'`, and `app.ts` / `package.ts` feed `@quilted/rollup` `Plugin` objects into Vite's plugin array). ~11 of the errors are `rolldown.PluginContext` / `rollup.Plugin` ↔ `vite.Plugin` mismatches that need a typing decision (adopt rolldown's types, or a compat shim).
- **TS 6 dropped automatic ambient `@types` inclusion** for several leaf packages — `Buffer` / `process` / `node:*` imports in `packages/hono/source/node.ts`, `integrations/cloudflare/source/craft.ts`, and a couple of tests need explicit `@types/node` (`types: ["node"]` or a triple-slash ref). (7× TS2591.)
- `tests/e2e/async.test.ts` uses `declare module X {}` where TS 6 now requires the `namespace` keyword (1× TS1540).

Widening the ranges unblocks consumers immediately; the Vite 8 self-migration can land separately.

## Downstream note (TS 6 inference regressions)

While migrating a consumer (a workspace on `@quilted/vite`) to TS 6, I hit two spots where TS 6 collapses quilt-derived types to `never` even though the runtime values are fine — worth a look when quilt itself moves to TS 6:

- The **`@quilted/async` cache-entry `.value`** generic (reached via `GraphQLCache.create(...).value`) infers as `never` under TS 6 (5.9 inferred it correctly).
- A **cross-module-augmented interface field** whose type references a non-exported interface from the augmenting module also collapsed to `never`.

Both were verified with `satisfies` probes (the real types are `GraphQLResult<Data>` / the augmented shape, not `never`).

## Validation

Peer-range changes only — no resolved versions change, lockfile untouched, quilt's own `type-check` / `build` / `test` stay on Vite 7 / Vitest 3 and remain green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)