### PR TITLE
Keep preview publishing on NPM_TOKEN

### DIFF
--- a/.github/workflows/preview-versions.yml
+++ b/.github/workflows/preview-versions.yml
@@ -11,11 +11,6 @@ jobs:
     name: Preview 🔮
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    permissions:
-      # Mint the OIDC token pnpm exchanges for a short-lived npm token
-      # (npm trusted publishing). Replaces the NPM_TOKEN secret.
-      id-token: write
-      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/workflows/actions/prepare
@@ -32,14 +27,16 @@ jobs:
       - uses: ./.github/workflows/actions/type-check-with-cache
       - run: pnpm run build
       - name: Deploy preview versions to NPM
-        # Publish with pnpm (not `changeset publish`) so releases go out over
-        # pnpm's OIDC trusted publishing, matching the main deploy workflow.
-        # `--no-git-checks` is required because `changeset version` dirties the
-        # working tree. GITHUB_TOKEN stays for @changesets/changelog-github,
-        # which hits the GitHub API during `changeset version`.
+        # Publish with pnpm rather than `changeset publish`. This path stays on
+        # token auth (NODE_AUTH_TOKEN): npm trusted publishing allows only one
+        # workflow per package, and that slot is taken by deploy.yml. So no
+        # OIDC/provenance here. `--no-git-checks` is required because
+        # `changeset version` dirties the working tree. GITHUB_TOKEN stays for
+        # @changesets/changelog-github, which hits the GitHub API during
+        # `changeset version`.
         run: |
           pnpm changeset version --snapshot preview
           pnpm publish -r --tag preview --no-git-checks
         env:
-          npm_config_provenance: 'true'
           GITHUB_TOKEN: ${{ secrets.RELEASES_GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What

Restores token auth (`NODE_AUTH_TOKEN`) for the preview/snapshot publish path and removes the OIDC-only bits that #944 added.

## Why — this fixes a break on `main`

npm trusted publishing allows **only one trusted publisher per package**, keyed to a single workflow filename. Every package's slot is already taken by `deploy.yml` (#943). Registering a second config for `preview-versions.yml` returns **409 Conflict**, and the reusable-workflow workaround doesn't apply (npm matches the top-level caller filename — npm/documentation#1755).

#944 removed `NODE_AUTH_TOKEN` from `preview-versions.yml` on the assumption OIDC would cover it. Since OIDC can't be configured for that workflow, the merged change left **preview publishing with no auth path** — it would fail the next time it runs. This restores it.

## Changes

- Re-add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`.
- Remove the `permissions: { id-token, contents }` block (OIDC-only).
- Remove `npm_config_provenance` (provenance generation requires `id-token: write`).
- **Keep** the `pnpm publish -r` swap — it works fine over token auth.

<details>
<summary>preview-versions.yml diff</summary>

```yaml
     timeout-minutes: 10
-    permissions:
-      id-token: write
-      contents: read
     steps:
       ...
         run: |
           pnpm changeset version --snapshot preview
           pnpm publish -r --tag preview --no-git-checks
         env:
-          npm_config_provenance: 'true'
           GITHUB_TOKEN: ${{ secrets.RELEASES_GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
```
</details>

## Net result

- `deploy.yml` (main releases): OIDC trusted publishing, token-free ✅
- `preview-versions.yml`: token auth via `NPM_TOKEN` (keep the secret) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)