### PR TITLE
ci: update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/actions/prepare/action.yml
+++ b/.github/workflows/actions/prepare/action.yml
@@ -2,8 +2,8 @@ name: Prepare repo
 runs:
   using: 'composite'
   steps:
-    - uses: pnpm/action-setup@v4.0.0
-    - uses: actions/setup-node@v4
+    - uses: pnpm/action-setup@v6
+    - uses: actions/setup-node@v6
       with:
         cache: pnpm
         registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/actions/type-check-with-cache/action.yml
+++ b/.github/workflows/actions/type-check-with-cache/action.yml
@@ -2,7 +2,7 @@ name: Type Check with cache
 runs:
   using: 'composite'
   steps:
-    - uses: actions/cache@v4
+    - uses: actions/cache@v5
       id: typescript-cache
       with:
         path: |

--- a/.github/workflows/changesets-reminder.yml
+++ b/.github/workflows/changesets-reminder.yml
@@ -10,6 +10,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   remind:
     name: Changeset Reminder
@@ -17,13 +21,51 @@ jobs:
     timeout-minutes: 5
     if: ${{ !github.event.pull_request.draft && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: mskelton/changelog-reminder-action@v3
+      # Inlined to replace mskelton/changelog-reminder-action, which had no
+      # Node 24 release. Posts a reminder comment when a PR touches package
+      # source without adding a `.changeset` entry, and resolves it once one
+      # is added. The comment is keyed by a hidden marker so it is updated in
+      # place rather than duplicated.
+      - uses: actions/github-script@v8
         with:
-          changelogRegex: "\\.changeset"
-          message: >
-            We detected some changes in `packages/*/package.json` or `packages/*/source`, and there are no updates in the `.changeset` directory.
+          script: |
+            const {owner, repo} = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const MARKER = '<!-- changeset-reminder -->';
+            const message = [
+              MARKER,
+              'We detected some changes in `packages/*/package.json` or `packages/*/source`, and there are no updates in the `.changeset` directory.',
+              '',
+              'If the changes are user-facing and should cause a version bump, run `pnpm changeset` to track your changes and include them in the next release CHANGELOG.',
+              '',
+              'If you are making simple updates to repo configuration, examples, or documentation, you do not need to add a changeset.',
+            ].join('\n');
 
-            If the changes are user-facing and should cause a version bump, run `pnpm changeset` to track your changes and include them in the next release CHANGELOG.
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: issue_number,
+              per_page: 100,
+            });
+            const hasChangeset = files.some((file) => /\.changeset/.test(file.filename));
 
-            If you are making simple updates to repo configuration, examples, or documentation, you do not need to add a changeset.
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner,
+              repo,
+              issue_number,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(MARKER));
+
+            if (hasChangeset) {
+              if (existing) {
+                await github.rest.issues.deleteComment({owner, repo, comment_id: existing.id});
+              }
+              return;
+            }
+
+            if (existing) {
+              await github.rest.issues.updateComment({owner, repo, comment_id: existing.id, body: message});
+            } else {
+              await github.rest.issues.createComment({owner, repo, issue_number, body: message});
+            }

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
       - run: pnpm run lint
 
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
       - uses: ./.github/workflows/actions/type-check-with-cache
 
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
       - name: Build libraries for unit tests
         run: |
@@ -42,11 +42,11 @@ jobs:
     env:
       PLAYWRIGHT_BROWSERS_PATH: /home/runner/.cache/ms-playwright
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
       - name: Restore Playwright browser cache
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /home/runner/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
@@ -65,10 +65,10 @@ jobs:
       matrix:
         parallel: [1/3, 2/3, 3/3]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
       - name: Restore Playwright browser cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /home/runner/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,7 +24,7 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
       - uses: ./.github/workflows/actions/type-check-with-cache
       - run: pnpm run build

--- a/.github/workflows/preview-versions.yml
+++ b/.github/workflows/preview-versions.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/workflows/actions/prepare
 
       # Changeset entries are consumed on this branch. We need to reset the

--- a/.github/workflows/release-notifier.yml
+++ b/.github/workflows/release-notifier.yml
@@ -10,17 +10,32 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # @see https://github.com/rjstone/discord-webhook-notify
-      - uses: rjstone/discord-webhook-notify@v1
-        with:
-          severity: info
-          color: '#1EE084'
-          text: New release from [Quilt](https://github.com/lemonmade/quilt)!
-          description: >
-            **${{ github.event.release.tag_name }}**
-
-            Published by [${{ github.event.release.author.login }}](${{ github.event.release.author.html_url }})
-
-            ${{ github.event.release.html_url }}
-          footer: ${{ github.event.release.published_at }}
-          webhookUrl: ${{ secrets.DISCORD_WEBHOOK_URL }}
+      # Posted directly to the Discord webhook with curl. The previous
+      # rjstone/discord-webhook-notify action had no Node 24 release, and curl
+      # has no runtime to deprecate. Release fields are passed through the
+      # environment (not interpolated into the script) to avoid injection.
+      - name: Post to Discord
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+          RELEASE_AUTHOR_LOGIN: ${{ github.event.release.author.login }}
+          RELEASE_AUTHOR_URL: ${{ github.event.release.author.html_url }}
+          RELEASE_PUBLISHED_AT: ${{ github.event.release.published_at }}
+        run: |
+          payload=$(jq -n \
+            --arg tag "$RELEASE_TAG" \
+            --arg url "$RELEASE_URL" \
+            --arg login "$RELEASE_AUTHOR_LOGIN" \
+            --arg author_url "$RELEASE_AUTHOR_URL" \
+            --arg published_at "$RELEASE_PUBLISHED_AT" \
+            '{
+              content: "New release from [Quilt](https://github.com/lemonmade/quilt)!",
+              embeds: [{
+                color: 2023556,
+                description: "**\($tag)**\n\nPublished by [\($login)](\($author_url))\n\n\($url)",
+                footer: {text: $published_at}
+              }]
+            }')
+          curl -fsSL -X POST -H "Content-Type: application/json" \
+            -d "$payload" "$DISCORD_WEBHOOK_URL"


### PR DESCRIPTION
## What

Updates all GitHub Actions to runtimes that aren't deprecated, clearing the **"Node.js 20 actions are deprecated"** warnings that appear on every workflow run (e.g. [PR #954's checks](https://github.com/lemonmade/quilt/pull/954/checks)). GitHub forces these actions to Node 24 on **2026-06-16** and removes Node 20 from runners on 2026-09-16.

## Changes

**First-party / pnpm actions — bumped to their latest Node 24 majors:**

| Action | Before | After |
| --- | --- | --- |
| `actions/checkout` | v4 | v5 |
| `actions/setup-node` | v4 | v6 |
| `actions/cache` | v4 | v5 |
| `pnpm/action-setup` | v4.0.0 | v6 |

`changesets/action@v1` already resolves to a Node 24 build, so it's untouched.

**Two third-party actions had no Node 24 release, so they're replaced:**

- **`rjstone/discord-webhook-notify`** (Node 16; latest `v2.2.1` is only Node 20, also deprecated) → a plain `curl` POST to the Discord webhook in `release-notifier.yml`. No runtime to deprecate. The embed (color/text/footer) is preserved, and release fields are passed through `env` rather than interpolated into the script to avoid injection.
- **`mskelton/changelog-reminder-action`** (Node 16, no newer release) → an inline `actions/github-script@v8` step in `changesets-reminder.yml`. Same behavior — reminds when a PR touches package source without a `.changeset` entry — and now dedupes via a hidden marker comment and auto-resolves it once a changeset is added. Added a scoped `permissions: pull-requests: write` block.

## Notes for reviewers

- `setup-node@v6` has a breaking change that limits *automatic* caching to npm; this repo sets `cache: pnpm` explicitly, which is unaffected.
- CI-config only, so no changeset.
- The unrelated `git failed with exit code 128` warning on the Changesets job is normal changesets-action output when there's nothing to release — not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)