### PR TITLE
Tie the preload `Link` header to streaming (structured `stream` option)

### DIFF
--- a/.changeset/preload-headers-option.md
+++ b/.changeset/preload-headers-option.md
@@ -1,0 +1,19 @@
+---
+'@quilted/preact-browser': patch
+---
+
+Tie the asset-preload `Link` response header to streaming, and add a structured `stream` option
+
+`renderAppToHTMLResponse` / `renderToHTMLResponse` emitted a `Link` response header preloading the entry's assets on every render. That header duplicates the `<link rel="modulepreload">` / `rel="stylesheet">` tags already in the document `<head>`, and for a large entry preload set it can exceed HTTP/3 (QPACK) header-size limits — stalling the response in browsers that negotiate HTTP/3 (the document hangs `pending`), while HTTP/2 clients are unaffected.
+
+The header only helps as an early hint while a response is still **streaming**; for a buffered response it's pure duplication. So it now follows the streaming setting, and `stream` accepts a structured form to control the two independently:
+
+```ts
+stream?: boolean | {html?: boolean; preload?: boolean}
+```
+
+- `false` (default): buffer the HTML and **do not** emit the preload header.
+- `true`: stream the HTML and emit the preload header.
+- `{html?, preload?}`: control each independently (e.g. `{html: true, preload: false}` to stream without the header). `preload` defaults to `html`.
+
+Note: this changes the default for buffered responses — they no longer emit the preload `Link` header. Pass `stream: {preload: true}` to restore it.

--- a/packages/preact-browser/source/server/render.tsx
+++ b/packages/preact-browser/source/server/render.tsx
@@ -33,6 +33,27 @@ const PLACEHOLDER_ELEMENT_REGEX =
 
 const CONTENT_PLACEHOLDER_REGEX = /html-template-placeholder-content/i;
 
+/**
+ * Normalizes the `stream` option into independent `html` (stream the response
+ * body) and `preload` (emit the asset-preload `Link` header) flags.
+ *
+ * The preload header only helps as an early hint while a response is still
+ * streaming; for a buffered response it duplicates the in-document `<link>`
+ * preload tags and, when the preload set is large, can exceed HTTP/3 (QPACK)
+ * header-size limits. So it defaults to following `html`: on when streaming,
+ * off when buffered. Either can be overridden via the object form.
+ */
+function resolveStreamOptions(
+  stream: boolean | {html?: boolean; preload?: boolean} | undefined,
+): {html: boolean; preload: boolean} {
+  if (stream == null || typeof stream === 'boolean') {
+    return {html: stream === true, preload: stream === true};
+  }
+
+  const html = stream.html ?? false;
+  return {html, preload: stream.preload ?? html};
+}
+
 export async function renderAppToHTMLResponse(
   renderApp: RenderAppValue,
   {
@@ -41,16 +62,35 @@ export async function renderAppToHTMLResponse(
     headers,
     serializations,
     template,
-    stream: shouldStream = false,
+    stream,
   }: {
     request: Request;
     assets?: BrowserAssets;
     serializations?: Iterable<[string, unknown]>;
     headers?: HeadersInit;
     template?: string | VNode<any>;
-    stream?: boolean;
+    /**
+     * Controls HTML streaming and the asset-preload `Link` response header.
+     *
+     * - `false` (default): buffer the full HTML and do **not** emit the preload
+     *   `Link` header. The document already carries the equivalent
+     *   `<link rel="modulepreload">` / `rel="stylesheet">` tags, so for a
+     *   buffered response the header is pure duplication — and a large preload
+     *   set can exceed HTTP/3 (QPACK) header-size limits, stalling the response
+     *   in browsers that negotiate HTTP/3.
+     * - `true`: stream the HTML and emit the preload `Link` header, so the
+     *   browser/CDN can begin preloading (or send Early Hints) before the
+     *   streamed body completes.
+     * - `{html?, preload?}`: control each independently — e.g. stream without
+     *   the header, or emit the header for a buffered response. `preload`
+     *   defaults to `html`.
+     */
+    stream?: boolean | {html?: boolean; preload?: boolean};
   },
 ) {
+  const {html: shouldStream, preload: shouldEmitPreloadHeader} =
+    resolveStreamOptions(stream);
+
   const resolvedHeaders = new Headers(headers);
 
   const browser = new BrowserResponse({
@@ -71,13 +111,15 @@ export async function renderAppToHTMLResponse(
       ...(entryAssets.style?.syncDependencies ?? []),
     ];
 
-    browser.headers.append(
-      'Link',
-      [
-        ...entryStyles.map((style) => preloadStyleAssetHeader(style)),
-        ...entryScripts.map((script) => preloadScriptAssetHeader(script)),
-      ].join(', '),
-    );
+    if (shouldEmitPreloadHeader) {
+      browser.headers.append(
+        'Link',
+        [
+          ...entryStyles.map((style) => preloadStyleAssetHeader(style)),
+          ...entryScripts.map((script) => preloadScriptAssetHeader(script)),
+        ].join(', '),
+      );
+    }
   }
 
   const response = await generateResponse(async () => {
@@ -232,15 +274,34 @@ export async function renderToHTMLResponse(
     assets,
     headers,
     serializations,
-    stream: shouldStream = false,
+    stream,
   }: {
     request: Request;
     assets?: BrowserAssets;
     headers?: HeadersInit;
     serializations?: Iterable<[string, unknown]>;
-    stream?: boolean;
+    /**
+     * Controls HTML streaming and the asset-preload `Link` response header.
+     *
+     * - `false` (default): buffer the full HTML and do **not** emit the preload
+     *   `Link` header. The document already carries the equivalent
+     *   `<link rel="modulepreload">` / `rel="stylesheet">` tags, so for a
+     *   buffered response the header is pure duplication — and a large preload
+     *   set can exceed HTTP/3 (QPACK) header-size limits, stalling the response
+     *   in browsers that negotiate HTTP/3.
+     * - `true`: stream the HTML and emit the preload `Link` header, so the
+     *   browser/CDN can begin preloading (or send Early Hints) before the
+     *   streamed body completes.
+     * - `{html?, preload?}`: control each independently — e.g. stream without
+     *   the header, or emit the header for a buffered response. `preload`
+     *   defaults to `html`.
+     */
+    stream?: boolean | {html?: boolean; preload?: boolean};
   },
 ) {
+  const {html: shouldStream, preload: shouldEmitPreloadHeader} =
+    resolveStreamOptions(stream);
+
   const resolvedHeaders = new Headers(headers);
 
   const browser = new BrowserResponse({
@@ -261,13 +322,15 @@ export async function renderToHTMLResponse(
       ...(entryAssets.style?.syncDependencies ?? []),
     ];
 
-    resolvedHeaders.append(
-      'Link',
-      [
-        ...entryStyles.map((style) => preloadStyleAssetHeader(style)),
-        ...entryScripts.map((script) => preloadScriptAssetHeader(script)),
-      ].join(', '),
-    );
+    if (shouldEmitPreloadHeader) {
+      resolvedHeaders.append(
+        'Link',
+        [
+          ...entryStyles.map((style) => preloadStyleAssetHeader(style)),
+          ...entryScripts.map((script) => preloadScriptAssetHeader(script)),
+        ].join(', '),
+      );
+    }
   }
 
   const response = await generateResponse(async () => {


### PR DESCRIPTION
## Motivation

`renderAppToHTMLResponse` / `renderToHTMLResponse` always append a `Link` response header preloading the entry's assets:

```ts
browser.headers.append('Link', [
  ...entryStyles.map(preloadStyleAssetHeader),
  ...entryScripts.map(preloadScriptAssetHeader),
].join(', '));
```

That **duplicates** the `<link rel="modulepreload">` / `rel="stylesheet">` tags already rendered into the document `<head>` (the header URLs are a strict subset of the in-document tags). For an app whose entry has a large preload set, the header grows large — in one real case ~37 KB / ~225 entries — and a single header field that size **exceeds HTTP/3 (QPACK) header-size limits**. Browsers that negotiate HTTP/3 then stall on the response (document sits `pending`, 0 bytes, no error), while `curl` / HTTP/2 clients receive the full buffered response fine. A nasty, transport-specific hang that doesn't reproduce in most tooling.

## Change

The preload `Link` header only earns its keep as an **early hint while a response is still streaming**; for a buffered response it arrives with the body and is pure duplication. So tie it to streaming, and let callers control the two independently:

```ts
stream?: boolean | {html?: boolean; preload?: boolean}
```

- **`false` (default)** — buffer the HTML and **do not** emit the preload header.
- **`true`** — stream the HTML and emit the preload header.
- **`{html?, preload?}`** — control each independently (e.g. `{html: true, preload: false}` to stream without the header, or `{html: false, preload: true}` to keep the header on a buffered response). `preload` defaults to `html`.

Applied to both `renderAppToHTMLResponse` and `renderToHTMLResponse`, with a `patch` changeset.

## Note on the default change

Buffered responses (`stream` falsy) no longer emit the preload `Link` header. That's the safer default — it's redundant with the in-document tags and is the configuration that trips HTTP/3. Callers who want it back pass `stream: {preload: true}`. Streaming behavior (`stream: true`) is unchanged: still streams **and** emits the header.