### PR TITLE
[preact-router] Accept a signal of routes in `Routes`/`useRoutes`

### DIFF
--- a/.changeset/routes-signal-list.md
+++ b/.changeset/routes-signal-list.md
@@ -1,0 +1,9 @@
+---
+'@quilted/preact-router': patch
+---
+
+`Routes` and `useRoutes` now accept a signal of the route list, in addition to a plain array.
+
+When the active route tree is swapped based on the current URL (e.g. a cross-scope navigation that activates a different set of routes), passing the list as a plain array makes it a prop gated on the parent component's render — so it lags the `currentRequest` signal the matcher reads directly. For one render the matcher sees the new URL against the old tree, which can mis-match nested routes (the router's per-request entry cache keys entries by structural position, so two trees matched for one navigation can collide and render the wrong route).
+
+Passing the list as a signal derived from the URL keeps both updates in a single glitch-free signal graph, so the matcher re-matches against the new tree in the same tick the URL changes and never observes a mismatched URL/tree pair.

--- a/packages/preact-router/source/components/Routes.tsx
+++ b/packages/preact-router/source/components/Routes.tsx
@@ -1,3 +1,5 @@
+import type {ReadonlySignal} from '@quilted/signals';
+
 import type {RouteDefinition} from '../types.ts';
 import {useRoutes} from '../hooks/routes.tsx';
 
@@ -5,7 +7,9 @@ export function Routes<Context = unknown>({
   list,
   context,
 }: {
-  list: readonly RouteDefinition<any, any, Context>[];
+  list:
+    | readonly RouteDefinition<any, any, Context>[]
+    | ReadonlySignal<readonly RouteDefinition<any, any, Context>[]>;
   context?: Context;
 }) {
   return useRoutes(list, {context});

--- a/packages/preact-router/source/hooks/routes.tsx
+++ b/packages/preact-router/source/hooks/routes.tsx
@@ -6,6 +6,7 @@ import {
   computed,
   effect,
   untracked,
+  isSignal,
   type ReadonlySignal,
 } from '@quilted/signals';
 import {
@@ -17,7 +18,9 @@ import type {RouteDefinition, RouteNavigationEntry} from '../types.ts';
 import type {Navigation} from '../Navigation.ts';
 
 export function useRoutes<Context = unknown>(
-  routes: readonly RouteDefinition<any, any, Context>[],
+  routes:
+    | readonly RouteDefinition<any, any, Context>[]
+    | ReadonlySignal<readonly RouteDefinition<any, any, Context>[]>,
   {context}: {context?: Context} = {},
 ) {
   const navigation = useQuiltContext('navigation');
@@ -27,16 +30,28 @@ export function useRoutes<Context = unknown>(
     const cache = navigation.cache;
 
     return computed(() => {
-      const matched = cache.match(navigation.currentRequest, routes, {
+      // Resolving the list inside the `computed` (rather than capturing it in
+      // the `useMemo` deps) lets a *signal* of routes re-match in the same tick
+      // the URL changes. A route tree that is swapped based on the current URL
+      // (e.g. a cross-scope navigation that activates a different set of
+      // routes) is otherwise a prop gated on the parent's render, so it lags
+      // the `currentRequest` signal the matcher reads directly — for one render
+      // the matcher sees the new URL against the old tree. Passing the list as
+      // a signal derived from the URL keeps both updates in one glitch-free
+      // graph, so the matcher never sees a mismatched URL/tree pair.
+      const list = isSignal(routes) ? routes.value : routes;
+
+      const matched = cache.match(navigation.currentRequest, list, {
         parent: parentEntry,
         context,
       });
 
       return matched;
     });
-    // Include `routes`/`context` so a route tree that is swapped in place
-    // (e.g. a navigation that changes which set of routes is active) re-matches
-    // against the new tree instead of the one captured when this hook first ran.
+    // Include `routes`/`context` so a route tree swapped in place as a plain
+    // array (new identity each render) still re-matches against the new tree.
+    // When `routes` is a signal its identity is stable and the `computed` above
+    // tracks its value reactively instead.
   }, [navigation, parentEntry, routes, context]);
 
   return (


### PR DESCRIPTION
## What

`Routes` and `useRoutes` now accept a `ReadonlySignal` of the route list, in addition to a plain array.

## Why

`useRoutes` matches inside a `computed` that reads `navigation.currentRequest` directly — so the matcher reacts to URL changes the instant they happen. The route list, however, is a prop gated on the parent component's render. When an app swaps the active route tree based on the current URL (e.g. a cross-scope navigation that activates a different set of routes), the URL signal flips a render before the new list prop arrives. For that one render the matcher sees **the new URL against the old tree**.

That transient can mis-match nested routes. The per-request entry cache keys entries by structural position (`${request.id}:${parentKey}:${routeKey}`), so two different trees matched for one navigation can produce the *same* entry id at a given slot and collide — rendering the wrong (cached) route at that position.

Passing the list as a signal derived from the URL keeps both updates in a single glitch-free signal graph: the matching `computed` resolves the list reactively, so it re-matches against the new tree in the same tick the URL changes and never observes a mismatched URL/tree pair.

## Change

- `useRoutes` / `Routes` accept `list: RouteDefinition[] | ReadonlySignal<RouteDefinition[]>`.
- The list is resolved with `isSignal(...) ? .value : ...` **inside** the matching `computed`, so a signal's value is tracked reactively (a stable signal identity also means the `useMemo` no longer re-runs per route change — the `computed` handles it). Plain arrays behave exactly as before.

## Notes

Found while debugging a cross-scope SPA navigation in an app that swaps its whole route tree on scope: the unscoped tree (with a `/` redirect) and the scoped tree (a frame matching `true` with a `/` home child) matched for one navigation collided on the same entry id, rendering the redirect in the home slot (blank page). A signal-derived route list removes the transient at the source.