### PR TITLE
Support graphql@17

### DIFF
--- a/.changeset/graphql-17-peer-support.md
+++ b/.changeset/graphql-17-peer-support.md
@@ -1,0 +1,10 @@
+---
+'@quilted/graphql': minor
+'@quilted/graphql-tools': minor
+'@quilted/rollup': minor
+'@quilted/quilt': minor
+---
+
+Allow `graphql@17`
+
+Widen the `graphql` version range to `^16.8.0 || ^17.0.0` (`^16.14.0 || ^17.0.0` for `@quilted/quilt`'s peer dependency) so consumers can adopt graphql-js 17. The packages only use the stable `parse` / `print` / `printSchema` / `Source` / `graphql()` / `GraphQLSchema` surface, which is unchanged across the major, so no code changes are required.

--- a/.changeset/graphql-17-peer-support.md
+++ b/.changeset/graphql-17-peer-support.md
@@ -5,6 +5,7 @@
 '@quilted/quilt': minor
 ---
 
-Allow `graphql@17`
+Support `graphql@17`
 
-Widen the `graphql` version range to `^16.8.0 || ^17.0.0` (`^16.14.0 || ^17.0.0` for `@quilted/quilt`'s peer dependency) so consumers can adopt graphql-js 17. The packages only use the stable `parse` / `print` / `printSchema` / `Source` / `graphql()` / `GraphQLSchema` surface, which is unchanged across the major, so no code changes are required.
+- Widen the `graphql` version range to `^16.8.0 || ^17.0.0` (`^16.14.0 || ^17.0.0` for `@quilted/quilt`'s peer dependency) so consumers can adopt graphql-js 17.
+- Fix custom scalar coercion under graphql 17: `createGraphQLSchema` now also assigns the renamed `coerceOutputValue` / `coerceInputValue` / `coerceInputLiteral` methods, not only the legacy `serialize` / `parseValue` / `parseLiteral`. graphql-js 17 reads the new names at execution and fixes them at construction, so without this a custom scalar's input validation silently stopped running (e.g. a bad value passed through a variable was accepted). No effect on graphql 16, where the extra properties are ignored.

--- a/packages/graphql-tools/package.json
+++ b/packages/graphql-tools/package.json
@@ -83,7 +83,7 @@
     "cosmiconfig-toml-loader": "^1.0.0",
     "esbuild": "^0.25.0",
     "globby": "^13.2.0",
-    "graphql": "^16.8.0",
+    "graphql": "^16.8.0 || ^17.0.0",
     "is-glob": "^4.0.0",
     "p-limit": "^4.0.0"
   },

--- a/packages/graphql/package.json
+++ b/packages/graphql/package.json
@@ -61,6 +61,6 @@
     "@quilted/async": "workspace:^",
     "@types/chance": "^1.1.3",
     "chance": "^1.1.7",
-    "graphql": "^16.8.0"
+    "graphql": "^16.8.0 || ^17.0.0"
   }
 }

--- a/packages/graphql/source/schema.ts
+++ b/packages/graphql/source/schema.ts
@@ -7,6 +7,14 @@ import {
   type GraphQLSchema,
 } from 'graphql';
 
+// graphql-js 17 renamed the scalar coercion methods; map each legacy name to
+// its v17 equivalent so customisations apply on both majors.
+const SCALAR_COERCION_ALIASES: Record<string, string> = {
+  serialize: 'coerceOutputValue',
+  parseValue: 'coerceInputValue',
+  parseLiteral: 'coerceInputLiteral',
+};
+
 export function createGraphQLSchema(
   source: string,
   resolvers: Record<string, Record<string, any>> = {},
@@ -19,9 +27,17 @@ export function createGraphQLSchema(
 
     if (isScalarType(type)) {
       for (const fieldName in resolverValue) {
-        (type as any)[
-          fieldName.startsWith('__') ? fieldName.substring(2) : fieldName
-        ] = resolverValue[fieldName];
+        const key = fieldName.startsWith('__')
+          ? fieldName.substring(2)
+          : fieldName;
+        const value = resolverValue[fieldName];
+        (type as any)[key] = value;
+        // graphql-js 17 renamed the scalar coercion methods and reads the new
+        // names at execution time (the old ones linger only as deprecated
+        // config aliases). Set both so a customised `serialize` / `parseValue`
+        // / `parseLiteral` keeps taking effect on graphql 16 *and* 17.
+        const renamed = SCALAR_COERCION_ALIASES[key];
+        if (renamed != null) (type as any)[renamed] = value;
       }
     } else if (isUnionType(type)) {
       for (const fieldName in resolverValue) {

--- a/packages/graphql/source/server/tests/server.test.ts
+++ b/packages/graphql/source/server/tests/server.test.ts
@@ -1,6 +1,11 @@
 import {describe, it, expect} from 'vitest';
 
-import {graphql as runGraphQL, type GraphQLSchema} from 'graphql';
+import {
+  graphql as runGraphQL,
+  GraphQLError,
+  Kind,
+  type GraphQLSchema,
+} from 'graphql';
 
 import {graphql} from '../../gql.ts';
 import {createGraphQLSchema} from '../../schema.ts';
@@ -120,6 +125,69 @@ describe('resolvers', () => {
     expect(mollyResult).toStrictEqual({
       dog: {name: 'Molly', nickname: null},
     });
+  });
+});
+
+describe('scalar coercion', () => {
+  // graphql-js 17 reads the renamed `coerceInputValue` / `coerceOutputValue` /
+  // `coerceInputLiteral` scalar methods at execution and fixes them at
+  // construction, so `createGraphQLSchema` must assign those (not only the
+  // legacy `serialize` / `parseValue` / `parseLiteral`) for a custom scalar's
+  // input validation to keep running. Without it, a bad value passed through a
+  // variable is silently accepted on v17. Verified against graphql 16 and 17.
+  function schemaWithTimezone() {
+    return createGraphQLSchema(
+      graphql`
+        scalar Timezone
+        type Query {
+          echo(timezone: Timezone!): Timezone!
+        }
+      `,
+      {
+        Timezone: {
+          __serialize: (value: unknown) => String(value),
+          __parseValue: (value: unknown) => {
+            if (typeof value !== 'string' || !value.includes('/')) {
+              throw new GraphQLError(`Invalid timezone: ${String(value)}`);
+            }
+            return value;
+          },
+          __parseLiteral: (ast: {kind: string; value?: string}) => {
+            if (ast.kind !== Kind.STRING || !ast.value?.includes('/')) {
+              throw new GraphQLError('Invalid timezone literal');
+            }
+            return ast.value;
+          },
+        },
+        Query: {
+          echo(_: unknown, {timezone}: {timezone: string}) {
+            return timezone;
+          },
+        },
+      },
+    );
+  }
+
+  it('runs a custom scalar parser on a variable value', async () => {
+    const result = await runGraphQL({
+      schema: schemaWithTimezone(),
+      source: `query ($tz: Timezone!) { echo(timezone: $tz) }`,
+      variableValues: {tz: 'Asia/Tokyo'},
+    });
+
+    expect(result.errors).toBeUndefined();
+    expect(result.data).toEqual({echo: 'Asia/Tokyo'});
+  });
+
+  it('rejects an invalid variable value at the scalar layer', async () => {
+    const result = await runGraphQL({
+      schema: schemaWithTimezone(),
+      source: `query ($tz: Timezone!) { echo(timezone: $tz) }`,
+      variableValues: {tz: 'not-a-timezone'},
+    });
+
+    expect(result.data).toBeUndefined();
+    expect(result.errors?.[0]?.message).toMatch(/Invalid timezone/);
   });
 });
 

--- a/packages/quilt/package.json
+++ b/packages/quilt/package.json
@@ -264,7 +264,7 @@
     "preact-render-to-string": "^6.7.0"
   },
   "peerDependencies": {
-    "graphql": "^16.14.0",
+    "graphql": "^16.14.0 || ^17.0.0",
     "preact": "^10.29.2",
     "prettier": "^2.0.0 || ^3.0.0",
     "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0"

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -156,7 +156,7 @@
     "es-module-lexer": "^1.6.0",
     "esbuild": "^0.25.0",
     "glob": "^10.3.10",
-    "graphql": "^16.8.0",
+    "graphql": "^16.8.0 || ^17.0.0",
     "lightningcss": "^1.29.0",
     "magic-string": "^0.30.17",
     "mrmime": "^1.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -497,8 +497,8 @@ importers:
         specifier: ^1.1.7
         version: 1.1.8
       graphql:
-        specifier: ^16.8.0
-        version: 16.8.1
+        specifier: ^16.8.0 || ^17.0.0
+        version: 16.14.2
 
   packages/graphql-tools:
     dependencies:
@@ -510,13 +510,13 @@ importers:
         version: 7.26.9
       '@graphql-tools/graphql-file-loader':
         specifier: ^8.0.0
-        version: 8.0.0(graphql@16.8.1)
+        version: 8.0.0(graphql@16.14.2)
       '@graphql-tools/json-file-loader':
         specifier: ^8.0.0
-        version: 8.0.0(graphql@16.8.1)
+        version: 8.0.0(graphql@16.14.2)
       '@graphql-tools/load':
         specifier: ^8.0.0
-        version: 8.0.0(graphql@16.8.1)
+        version: 8.0.0(graphql@16.14.2)
       '@quilted/graphql':
         specifier: workspace:^3.3.5
         version: link:../graphql
@@ -545,8 +545,8 @@ importers:
         specifier: ^13.2.0
         version: 13.2.2
       graphql:
-        specifier: ^16.8.0
-        version: 16.8.1
+        specifier: ^16.8.0 || ^17.0.0
+        version: 16.14.2
       is-glob:
         specifier: ^4.0.0
         version: 4.0.3
@@ -859,7 +859,7 @@ importers:
         specifier: workspace:^4.0.3
         version: link:../threads
       graphql:
-        specifier: ^16.14.0
+        specifier: ^16.14.0 || ^17.0.0
         version: 16.14.2
       jest-matcher-utils:
         specifier: ^30.0.0
@@ -1008,8 +1008,8 @@ importers:
         specifier: ^10.3.10
         version: 10.3.10
       graphql:
-        specifier: ^16.8.0
-        version: 16.8.1
+        specifier: ^16.8.0 || ^17.0.0
+        version: 16.14.2
       lightningcss:
         specifier: ^1.29.0
         version: 1.29.1
@@ -3679,10 +3679,6 @@ packages:
     resolution: {integrity: sha512-Chq1s4CY7jmh8gO2qvLIJyfCDIN+EHLFW/9iShnp1z8FjBQMoodWP1kDC36VAMXXIvAjj4ARa7ntfAV2BrjsbA==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
 
-  graphql@16.8.1:
-    resolution: {integrity: sha512-59LZHPdGZVh695Ud9lRzPBVTtlX9ZCV150Er2W43ro37wVof0ctenSaskPPjN7lVTIN8mSZt8PHUNKZuNQUuxw==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-
   has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
@@ -6264,61 +6260,61 @@ snapshots:
 
   '@exodus/bytes@1.15.1': {}
 
-  '@graphql-tools/graphql-file-loader@8.0.0(graphql@16.8.1)':
+  '@graphql-tools/graphql-file-loader@8.0.0(graphql@16.14.2)':
     dependencies:
-      '@graphql-tools/import': 7.0.0(graphql@16.8.1)
-      '@graphql-tools/utils': 10.0.1(graphql@16.8.1)
+      '@graphql-tools/import': 7.0.0(graphql@16.14.2)
+      '@graphql-tools/utils': 10.0.1(graphql@16.14.2)
       globby: 11.1.0
-      graphql: 16.8.1
+      graphql: 16.14.2
       tslib: 2.4.0
       unixify: 1.0.0
 
-  '@graphql-tools/import@7.0.0(graphql@16.8.1)':
+  '@graphql-tools/import@7.0.0(graphql@16.14.2)':
     dependencies:
-      '@graphql-tools/utils': 10.0.1(graphql@16.8.1)
-      graphql: 16.8.1
+      '@graphql-tools/utils': 10.0.1(graphql@16.14.2)
+      graphql: 16.14.2
       resolve-from: 5.0.0
       tslib: 2.6.0
 
-  '@graphql-tools/json-file-loader@8.0.0(graphql@16.8.1)':
+  '@graphql-tools/json-file-loader@8.0.0(graphql@16.14.2)':
     dependencies:
-      '@graphql-tools/utils': 10.0.1(graphql@16.8.1)
+      '@graphql-tools/utils': 10.0.1(graphql@16.14.2)
       globby: 11.1.0
-      graphql: 16.8.1
+      graphql: 16.14.2
       tslib: 2.4.0
       unixify: 1.0.0
 
-  '@graphql-tools/load@8.0.0(graphql@16.8.1)':
+  '@graphql-tools/load@8.0.0(graphql@16.14.2)':
     dependencies:
-      '@graphql-tools/schema': 10.0.0(graphql@16.8.1)
-      '@graphql-tools/utils': 10.0.1(graphql@16.8.1)
-      graphql: 16.8.1
+      '@graphql-tools/schema': 10.0.0(graphql@16.14.2)
+      '@graphql-tools/utils': 10.0.1(graphql@16.14.2)
+      graphql: 16.14.2
       p-limit: 3.1.0
       tslib: 2.4.0
 
-  '@graphql-tools/merge@9.0.0(graphql@16.8.1)':
+  '@graphql-tools/merge@9.0.0(graphql@16.14.2)':
     dependencies:
-      '@graphql-tools/utils': 10.0.1(graphql@16.8.1)
-      graphql: 16.8.1
+      '@graphql-tools/utils': 10.0.1(graphql@16.14.2)
+      graphql: 16.14.2
       tslib: 2.6.0
 
-  '@graphql-tools/schema@10.0.0(graphql@16.8.1)':
+  '@graphql-tools/schema@10.0.0(graphql@16.14.2)':
     dependencies:
-      '@graphql-tools/merge': 9.0.0(graphql@16.8.1)
-      '@graphql-tools/utils': 10.0.1(graphql@16.8.1)
-      graphql: 16.8.1
+      '@graphql-tools/merge': 9.0.0(graphql@16.14.2)
+      '@graphql-tools/utils': 10.0.1(graphql@16.14.2)
+      graphql: 16.14.2
       tslib: 2.6.0
       value-or-promise: 1.0.12
 
-  '@graphql-tools/utils@10.0.1(graphql@16.8.1)':
+  '@graphql-tools/utils@10.0.1(graphql@16.14.2)':
     dependencies:
-      '@graphql-typed-document-node/core': 3.1.1(graphql@16.8.1)
-      graphql: 16.8.1
+      '@graphql-typed-document-node/core': 3.1.1(graphql@16.14.2)
+      graphql: 16.14.2
       tslib: 2.6.0
 
-  '@graphql-typed-document-node/core@3.1.1(graphql@16.8.1)':
+  '@graphql-typed-document-node/core@3.1.1(graphql@16.14.2)':
     dependencies:
-      graphql: 16.8.1
+      graphql: 16.14.2
 
   '@hono/node-server@2.0.4(hono@4.12.25)':
     dependencies:
@@ -7732,8 +7728,6 @@ snapshots:
   graceful-fs@4.2.11: {}
 
   graphql@16.14.2: {}
-
-  graphql@16.8.1: {}
 
   has-flag@3.0.0: {}
 


### PR DESCRIPTION
Adds graphql-js 17 support to the GraphQL packages. Two parts:

### 1. Widen the version range
`graphql` → `^16.8.0 || ^17.0.0` across `@quilted/graphql`, `graphql-tools`, and `rollup` (regular deps), and `^16.14.0 || ^17.0.0` for `@quilted/quilt`'s peer. Because it's a regular `dependency` (not just a peer), leaving it at `^16` forces a downstream app onto **two** graphql copies the moment it adopts 17, tripping graphql-js's `instanceof` type checks. Widening lets pnpm dedupe to a single copy.

### 2. Fix custom scalar coercion under graphql 17
graphql-js 17 **renamed** the scalar coercion methods (`serialize`/`parseValue`/`parseLiteral` → `coerceOutputValue`/`coerceInputValue`/`coerceInputLiteral`) and now:
- **reads the new names at execution**, and
- **fixes them at construction** (`this.coerceInputValue = config.coerceInputValue ?? this.parseValue`).

`createGraphQLSchema` customises scalars by **mutating the type after `buildSchema`**, so setting only the legacy `parseValue` no longer takes effect — `coerceInputValue` was already locked to the identity default at construction. The result is a **silent** regression: a custom scalar's input validation stops running (e.g. an invalid value passed through a **variable** is accepted instead of rejected). The literal path happens to still validate, which makes it easy to miss.

Fix: when assigning a scalar method, also assign its v17 equivalent. No effect on graphql 16 (the extra properties are ignored there).

```ts
const SCALAR_COERCION_ALIASES = {
  serialize: 'coerceOutputValue',
  parseValue: 'coerceInputValue',
  parseLiteral: 'coerceInputLiteral',
};
// …in the scalar branch of createGraphQLSchema:
type[key] = value;
const renamed = SCALAR_COERCION_ALIASES[key];
if (renamed != null) type[renamed] = value;
```

### Verification
Added a regression test (`server.test.ts` → `scalar coercion`) that runs a custom scalar through `createGraphQLSchema` and asserts a bad value passed via a variable is rejected. Verified both ways:

- **graphql 16**: 4/4 pass (fix is a no-op).
- **graphql 17**: 4/4 pass **with** the fix; with the fix removed, `rejects an invalid variable value at the scalar layer` **fails** — confirming the test guards the regression and the fix resolves it.

(Couldn't run the full quilt suite on 17 in my environment without a full workspace build — recommend adding 17 to the test matrix to keep this guard active in CI. The fix itself is proven correct against graphql 17 above.)

Downstream consumer (sessions-app) needs this to pass an `AbortSignal` into `execute()` for cooperative request/DB cancellation; until this is published it bridges with a `pnpm.overrides.graphql` pin.