### PR TITLE
Declare a graphql peer on @quilted/preact-graphql

### DIFF
--- a/.changeset/preact-graphql-peer.md
+++ b/.changeset/preact-graphql-peer.md
@@ -1,0 +1,7 @@
+---
+'@quilted/preact-graphql': minor
+---
+
+Declare a `graphql` peer dependency (`^16.8.0 || ^17.0.0`, optional)
+
+`@quilted/preact-graphql` depends on `@quilted/graphql` but didn't declare its own `graphql` peer, so a consumer adopting graphql-js 17 could end up with the package's `@quilted/graphql` deduped against an older graphql 16 copy — leaving two graphql versions in the tree and tripping graphql's nominal `TypedDocumentNode` type checks. Declaring the peer lets the consumer's graphql resolve a single copy.

--- a/packages/preact-graphql/package.json
+++ b/packages/preact-graphql/package.json
@@ -46,9 +46,13 @@
     "@quilted/useful-types": "workspace:^2.0.0"
   },
   "peerDependencies": {
+    "graphql": "^16.8.0 || ^17.0.0",
     "preact": "^10.29.2"
   },
   "peerDependenciesMeta": {
+    "graphql": {
+      "optional": true
+    },
     "preact": {
       "optional": true
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -685,6 +685,9 @@ importers:
       '@quilted/useful-types':
         specifier: workspace:^2.0.0
         version: link:../useful-types
+      graphql:
+        specifier: ^16.8.0 || ^17.0.0
+        version: 16.14.2
     devDependencies:
       preact:
         specifier: 10.29.2


### PR DESCRIPTION
`@quilted/preact-graphql` depends on `@quilted/graphql` but declared no `graphql` peer of its own. A consumer adopting graphql-js 17 then ends up with the package's `@quilted/graphql` deduped against an older **graphql 16** copy, leaving two graphql versions in the tree and tripping graphql's nominal `TypedDocumentNode` type checks across the consuming app.

Declaring an optional `graphql: ^16.8.0 || ^17.0.0` peer (matching `@quilted/quilt`) lets the consumer's graphql resolve to a single copy.

Follow-up to #962 — that PR widened the graphql range across the GraphQL packages but missed `preact-graphql`, which only surfaces downstream as a dual-graphql type mismatch. With this, consumers can drop the `pnpm` graphql override they currently need.