### PR TITLE
Bump @quilted/preact-graphql's @quilted/graphql dep to ^3.5.0

### DIFF
--- a/.changeset/preact-graphql-graphql-dep.md
+++ b/.changeset/preact-graphql-graphql-dep.md
@@ -1,0 +1,7 @@
+---
+'@quilted/preact-graphql': patch
+---
+
+Track the current `@quilted/graphql`
+
+`@quilted/preact-graphql` still pinned `@quilted/graphql` at `^3.4.1` (it wasn't co-released when `@quilted/graphql` reached 3.5.0), so consumers on graphql-js 17 could resolve its `@quilted/graphql` to the older graphql-16-only build and end up with two graphql copies. Bump the range to `^3.5.0` to match the rest of the workspace.

--- a/packages/preact-graphql/package.json
+++ b/packages/preact-graphql/package.json
@@ -39,7 +39,7 @@
     "build": "rollup --config configuration/rollup.config.js"
   },
   "dependencies": {
-    "@quilted/graphql": "workspace:^3.4.1",
+    "@quilted/graphql": "workspace:^3.5.0",
     "@quilted/preact-async": "workspace:^0.1.24",
     "@quilted/preact-context": "workspace:^0.1.6",
     "@quilted/preact-signals": "workspace:^0.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -671,7 +671,7 @@ importers:
   packages/preact-graphql:
     dependencies:
       '@quilted/graphql':
-        specifier: workspace:^3.4.1
+        specifier: workspace:^3.5.0
         version: link:../graphql
       '@quilted/preact-async':
         specifier: workspace:^0.1.24


### PR DESCRIPTION
Completes #964. That PR added `@quilted/preact-graphql`'s `graphql` peer, but the package still pinned `@quilted/graphql` at `^3.4.1` — it was never co-released when `@quilted/graphql` reached 3.5.0, so changesets never updated the range (every other package — graphql-tools, quilt, rollup — already tracks `^3.5.0`).

The effect downstream: a consumer on graphql-js 17 resolves `preact-graphql`'s `@quilted/graphql` to the older **graphql-16-only** `3.4.2` build, leaving two graphql copies in the tree and tripping graphql's nominal `TypedDocumentNode` types. The peer wasn't enough on its own because `^3.4.1` still admits the old build.

Bumping the range to `^3.5.0` (matching the rest of the workspace) lets it resolve the graphql-17-capable build, so consumers can drop the `pnpm` graphql override.

Verified: `pnpm install --frozen-lockfile` passes (1-line lockfile diff).