### PR TITLE
Don't adopt the first history entry on a browser fragment navigation

### DIFF
--- a/.changeset/router-fragment-navigation.md
+++ b/.changeset/router-fragment-navigation.md
@@ -1,0 +1,20 @@
+---
+'@quilted/preact-router': patch
+---
+
+Stop browser fragment navigations from being adopted as the first history entry.
+
+Clicking an in-page link (`<a href="#section">`) is a same-document navigation
+the router did not perform: the browser pushes the entry with a null
+`history.state`, so there is no navigation id on it to recognise. `popstate`'s
+handler fell back to the _first_ entry of the session and adopted it wholesale,
+with two visible consequences — `currentRequest` reported the pre-fragment URL
+while the address bar showed the hash, and scroll restoration put the reader
+back at that entry's saved offset, undoing the jump the browser had just made.
+On a long document with a table of contents, every entry appeared to bounce the
+reader back to the top of the page.
+
+A cached request is now only adopted when its URL is actually the one that was
+landed on. An unrecognised entry gets an id of its own, stamped into
+`history.state` so a later traversal back to it is recognised, rather than
+overwriting the first entry's record and the scroll offset stored against it.

--- a/packages/preact-router/source/Navigation.ts
+++ b/packages/preact-router/source/Navigation.ts
@@ -316,13 +316,53 @@ export class Navigation {
 
     const url = getNavigationRequestURLFromEnvironment();
     const state = getNavigationRequestStateFromEnvironment();
-    const id = (state[STATE_ID_FIELD_KEY] as string) ?? fallbackNavigationID;
+    const stateID = state[STATE_ID_FIELD_KEY] as string | undefined;
+    const id = stateID ?? fallbackNavigationID;
 
     let request = this.#navigationRequests.get(id);
 
-    if (request == null) {
+    // Only adopt a cached request when it is actually the entry we landed on.
+    // Not every popstate comes from a navigation we performed: a same-document
+    // fragment navigation (the user clicking `<a href="#section">`) pushes an
+    // entry with a null `history.state`, so there is no id to recognise it by,
+    // and a foreign `pushState` leaves one we never recorded. Without the URL
+    // check those fall back to the *first* entry of the session and adopt it
+    // wholesale — reporting a stale `currentRequest` (the pre-fragment URL,
+    // while the address bar shows the hash) and restoring that entry's scroll
+    // offset, which undoes the jump the browser just made and drops the reader
+    // back at the top of the page.
+    if (request == null || request.url.href !== url.href) {
       request = {url, state, id};
-      this.#navigationRequests.set(id, request);
+
+      // An unrecognised entry needs an id of its own — reusing the fallback id
+      // would overwrite the first entry's record, and reusing another entry's
+      // id would corrupt the scroll offset stored against it.
+      if (stateID == null) {
+        const newID = createNavigationRequestID();
+        const finalState = {...state, [STATE_ID_FIELD_KEY]: newID};
+        request = {url, state: finalState, id: newID};
+
+        // Stamp the id into the entry so traversing back to it later is
+        // recognised rather than running through this path again.
+        try {
+          history.replaceState(finalState, '', urlToPath(url));
+        } catch {
+          // A state object the structured clone algorithm rejects, or a
+          // rate-limited `replaceState`. The request below still stands; only
+          // a later traversal back to this entry loses its identity.
+        }
+
+        const previousIndex = navigationIDs.lastIndexOf(
+          this.#currentRequest.peek().id,
+        );
+        navigationIDs.splice(
+          previousIndex + 1,
+          navigationIDs.length - previousIndex - 1,
+          newID,
+        );
+      }
+
+      this.#navigationRequests.set(request.id, request);
     }
 
     // const currentNavigationIndex = navigationIDs.lastIndexOf(

--- a/packages/preact-router/source/tests/Navigation.test.ts
+++ b/packages/preact-router/source/tests/Navigation.test.ts
@@ -277,6 +277,86 @@ describe('Navigation', () => {
       expect(scrollTo).toHaveBeenCalledWith(0, 420);
     });
 
+    // A same-document fragment navigation — the user clicking `<a href="#x">`
+    // — is a popstate we did not perform: the browser pushes the entry with a
+    // null `history.state`, so there is no id on it to recognise. Falling back
+    // to the first entry of the session adopted that entry wholesale, which
+    // restored its scroll offset over the jump the browser had just made and
+    // left `currentRequest` on the pre-fragment URL.
+    describe('browser fragment navigations', () => {
+      function fragmentNavigation(hash: string) {
+        // What the browser does on the click: push the entry with no state of
+        // ours on it, scroll to the target, then fire popstate.
+        window.history.pushState(null, '', `/home${hash}`);
+        window.dispatchEvent(new PopStateEvent('popstate', {state: null}));
+      }
+
+      function addTarget(id: string) {
+        const target = document.createElement('div');
+        target.id = id;
+        document.body.append(target);
+        const scrollIntoView = vi.fn();
+        target.scrollIntoView = scrollIntoView;
+        return {target, scrollIntoView};
+      }
+
+      afterEach(() => {
+        document.body.innerHTML = '';
+      });
+
+      it('scrolls to the fragment target rather than restoring the entry it left', () => {
+        new Navigation('https://example.com/home');
+        const {scrollIntoView} = addTarget('section');
+
+        fragmentNavigation('#section');
+
+        expect(scrollIntoView).toHaveBeenCalled();
+        // The reader was at the top when they clicked, so restoring the
+        // outgoing entry's offset is what dropped them back there.
+        expect(scrollTo).not.toHaveBeenCalledWith(0, 0);
+      });
+
+      it('reports the fragment URL as the current request', () => {
+        const navigation = new Navigation('https://example.com/home');
+        addTarget('section');
+
+        fragmentNavigation('#section');
+
+        expect(navigation.currentRequest.url.hash).toBe('#section');
+      });
+
+      it('stamps an id on the entry so traversing back to it is recognised', () => {
+        const navigation = new Navigation('https://example.com/home');
+        addTarget('section');
+
+        fragmentNavigation('#section');
+
+        expect(window.history.state).toMatchObject({
+          _id: navigation.currentRequest.id,
+        });
+      });
+
+      it('keeps the entry it left addressable by its own id', () => {
+        const navigation = new Navigation('https://example.com/home');
+        const homeId = navigation.currentRequest.id;
+        addTarget('section');
+        scrollOffset.y = 420;
+
+        fragmentNavigation('#section');
+        scrollTo.mockClear();
+
+        // Back to the pre-fragment entry: its offset must still be its own,
+        // not one the fragment entry overwrote.
+        window.history.replaceState({_id: homeId}, '', '/home');
+        window.dispatchEvent(
+          new PopStateEvent('popstate', {state: {_id: homeId}}),
+        );
+
+        expect(navigation.currentRequest.id).toBe(homeId);
+        expect(scrollTo).toHaveBeenCalledWith(0, 420);
+      });
+    });
+
     it('persists scroll positions to sessionStorage keyed by navigation id', () => {
       const navigation = new Navigation('https://example.com/home');
       const homeId = navigation.currentRequest.id;


### PR DESCRIPTION
## The bug

Clicking an in-page link — `<a href="#section">`, the shape every table of contents uses — is a same-document navigation the router did not perform. The browser pushes the entry with a **null `history.state`**, so there is no navigation id on it to recognise.

`#handlePopstate` fell back to `navigationIDs[0]` and adopted that entry wholesale:

```ts
const id = (state[STATE_ID_FIELD_KEY] as string) ?? fallbackNavigationID;
let request = this.#navigationRequests.get(id);   // ← the *first* entry, URL and all
```

Two visible consequences:

1. `currentRequest` reports the pre-fragment URL while the address bar shows the hash — so `useCurrentURL()`, route matching, and anything resolving relative to the current URL all run against a stale URL.
2. Scroll restoration restores that entry's saved offset, **overwriting the jump the browser just made**. On a long document, every contents entry appears to bounce the reader back to the top of the page.

I hit this on a privacy policy page: clicking any contents entry landed back at the top, with `window.scrollY === 0` while the target section sat ~2900px down and `location.href` carried the hash.

## The fix

Only adopt a cached request when its URL is actually the one that was landed on. An unrecognised entry — a fragment navigation, or a foreign `pushState` — gets an id of its own, stamped into `history.state` via `replaceState` so a later traversal back to it is recognised, rather than reusing the fallback id and clobbering the first entry's record and the scroll offset stored against it.

With that in place the existing scroll logic already does the right thing: the new entry has no saved offset and does have a hash, so `#restoreScrollPosition` scrolls to the hash target — the same place the browser went.

## Tests

Four cases under `scroll restoration > browser fragment navigations`, driving the real browser sequence (`pushState(null, …)` then a `popstate` with null state):

- scrolls to the fragment target rather than restoring the entry it left
- reports the fragment URL as the current request
- stamps an id on the entry so traversing back to it is recognised
- keeps the entry it left addressable by its own id, with its own scroll offset

The first three fail on `main` and pass with the fix; the fourth guards the fix itself against corrupting the previous entry. Full `preact-router` suite passes (89 passed, 1 skipped), type-check and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)