### PR TITLE
Resolve a fragment-only or search-only `to` against the current URL

### DIFF
--- a/.changeset/routing-fragment-only-to.md
+++ b/.changeset/routing-fragment-only-to.md
@@ -1,0 +1,20 @@
+---
+'@quilted/routing': patch
+---
+
+Resolve a fragment-only or search-only `to` against the current URL.
+
+`resolveURL` handled three shapes of string: one starting with `/` (an absolute
+path, prefixed with the base), one that parses as a full URL, and everything
+else as a **relative path**, joined onto the current pathname. A bare `#section`
+or `?page=2` fell into that last case, so an in-page link resolved to
+`/privacy/#section` — a different path than the page it was on — and dropped the
+search params along the way.
+
+Neither `#` nor `?` can begin a relative path, so both are unambiguous: they name
+a place on the page you are already on. They now resolve against the current URL
+with the URL parser, which keeps everything to the left untouched — the path, and
+for a fragment the search params too. The base prefix is not re-applied, since
+the pathname isn't changing.
+
+This makes `<Link to="#section">` and `navigate('#section')` work as written.

--- a/packages/routing/source/tests/utilities.test.ts
+++ b/packages/routing/source/tests/utilities.test.ts
@@ -32,6 +32,64 @@ describe('resolveURL', () => {
       expect(result.pathname).toBe('/page');
       expect(result.search).toBe('?key=value');
     });
+
+    // `#`/`?` can't begin a relative path, so these name a place on the page
+    // you are already on. Joining them onto the current pathname the way a
+    // relative path is joined produced `/privacy/#section` — a different page.
+    describe('fragment-only and search-only targets', () => {
+      it('keeps the current path when given a bare hash', () => {
+        const result = resolveURL(
+          '#section',
+          new URL('https://example.com/privacy'),
+        );
+
+        expect(result.pathname).toBe('/privacy');
+        expect(result.hash).toBe('#section');
+      });
+
+      it('keeps the current search params when given a bare hash', () => {
+        const result = resolveURL(
+          '#section',
+          new URL('https://example.com/privacy?locale=fr'),
+        );
+
+        expect(result.href).toBe(
+          'https://example.com/privacy?locale=fr#section',
+        );
+      });
+
+      it('replaces the search when given a bare search string', () => {
+        const result = resolveURL(
+          '?page=2',
+          new URL('https://example.com/activities?page=1'),
+        );
+
+        expect(result.pathname).toBe('/activities');
+        expect(result.search).toBe('?page=2');
+      });
+
+      // The pathname isn't changing, so the base is already on it — applying
+      // the prefix again would double it.
+      it('does not re-apply the base prefix', () => {
+        const result = resolveURL(
+          '#section',
+          new URL('https://example.com/app/privacy'),
+          '/app',
+        );
+
+        expect(result.pathname).toBe('/app/privacy');
+        expect(result.hash).toBe('#section');
+      });
+
+      it('replaces a hash that is already present', () => {
+        const result = resolveURL(
+          '#second',
+          new URL('https://example.com/privacy#first'),
+        );
+
+        expect(result.href).toBe('https://example.com/privacy#second');
+      });
+    });
   });
 
   describe('object form', () => {

--- a/packages/routing/source/utilities.ts
+++ b/packages/routing/source/utilities.ts
@@ -36,6 +36,19 @@ export function resolveURL(
   } else if (to[0] === '/') {
     const fromURL = typeof from === 'string' ? new URL(from) : from;
     return new URL(prefixPath(to, prefix), fromURL);
+  } else if (to[0] === '#' || to[0] === '?') {
+    // A fragment-only (`#section`, an in-page jump) or search-only (`?page=2`)
+    // target names a place on the page you are already on. It is not a relative
+    // path, and `#`/`?` can't begin one — so it must not fall through to the
+    // relative branch below, which would join it onto the current pathname
+    // (`/privacy` + `#section` → `/privacy/#section`, a different page).
+    //
+    // The URL parser already resolves both correctly against the current URL,
+    // keeping everything to the left untouched — the path, and for a fragment
+    // the search params too. The base prefix is deliberately not re-applied:
+    // the pathname isn't changing, and it already carries the prefix.
+    const fromURL = typeof from === 'string' ? new URL(from) : from;
+    return new URL(to, fromURL);
   } else {
     try {
       const url = new URL(to);


### PR DESCRIPTION
Follow-up to #990. That one fixed what the router did when the *browser* performed a fragment navigation; this fixes what happens when you ask the router to perform one yourself.

## The gap

`resolveURL` handles three shapes of string:

```ts
} else if (to[0] === '/') {          // absolute path, prefixed with the base
} else {
  try { return new URL(to); } catch {}   // a full URL
  return new URL(prefixPath(to, fromPart));   // …everything else: a relative path
}
```

A bare `#section` isn't absolute and doesn't parse as a URL, so it lands in the relative-path branch and gets joined onto the current pathname:

```
resolveURL('#section', new URL('https://example.com/privacy?locale=fr'))
  → https://example.com/privacy/#section     ← different path, search dropped
```

So `<Link to="#section">` — the natural way to write an in-page link — silently navigates somewhere else. The workaround is the function form (`to={(url) => …}`), which is a lot of ceremony for "jump to this section".

## The fix

Neither `#` nor `?` can begin a relative path, so both are unambiguous: they name a place on the page you are already on. Resolve them against the current URL with the URL parser, which keeps everything to the left untouched — the path, and for a fragment the search params too.

```
resolveURL('#section', new URL('https://example.com/privacy?locale=fr'))
  → https://example.com/privacy?locale=fr#section
```

The base prefix is deliberately **not** re-applied: the pathname isn't changing, and it already carries the prefix. Search-only targets (`?page=2`) get the same treatment, replacing the search and leaving the path alone.

## Blast radius

- **The object form is unaffected.** It composes `${finalPathname}${finalSearch}${finalHash}` and recurses, and `finalPathname` defaults to `fromURL.pathname`, so a composed string always begins with `/` and still takes the absolute-path branch. The existing object-form tests (including the base-doubling regression) still pass.
- **The only callers are `Navigation.navigate` and `Navigation.resolve`.** Nothing else in the monorepo calls `resolveURL`.
- Strings that previously resolved as relative paths are untouched — this branch is checked before that fallback and only matches a leading `#` or `?`.

## Tests

Five cases under `string form > fragment-only and search-only targets`: keeps the current path, keeps the current search params, replaces the search for a bare `?…`, doesn't re-apply the base prefix, and replaces a hash that's already present. All five fail on `main`.

Full monorepo unit suite passes (199 passed, 1 skipped), type-check and prettier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)